### PR TITLE
fix delete handler index

### DIFF
--- a/script.js
+++ b/script.js
@@ -165,8 +165,7 @@ document.addEventListener('DOMContentLoaded', () => {
             
             if (confirm('Are you sure you want to delete this entry?')) {
                 const tankData = getTankData(currentTankId);
-                const originalIndex = tankData.length - 1 - indexToDelete;
-                tankData.splice(originalIndex, 1);
+                tankData.splice(indexToDelete, 1);
                 saveTankData(currentTankId, tankData);
                 renderLog();
             }


### PR DESCRIPTION
## Summary
- fix delete handler index: delete the intended record directly using index

## Testing
- `node --check script.js`
- `npm test` *(fails: package.json not found)*
- `node -e "let arr=['a','b','c']; arr.splice(1,1); console.log(arr);"`

------
https://chatgpt.com/codex/tasks/task_e_68c5329fd394832dbbc082184d9ba334