### PR TITLE
Add export/import functionality for tank logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # fermentation-tracker
+
+Small client-side tool for recording fermentation readings for each tank.
+
+## Export and Import
+
+1. Select a tank using the dropdown.
+2. Click **Export** to download the tank's log. When prompted, choose JSON or CSV.
+3. To import, select the tank that should receive the data, click **Import**, and choose a JSON or CSV file.
+   The file's entries are merged into the tank's existing log sorted by timestamp.
+

--- a/index.html
+++ b/index.html
@@ -72,6 +72,13 @@
                     </tbody>
             </table>
         </section>
+
+        <section class="data-management">
+            <h2>Data Management</h2>
+            <button id="exportBtn">Export</button>
+            <input type="file" id="importFile" accept=".json,.csv" style="display: none;">
+            <button id="importBtn">Import</button>
+        </section>
     </main>
 
     <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- add Export and Import buttons with hidden file input
- implement JSON/CSV export and import merging into localStorage
- document data management workflow

## Testing
- `npm test` (fails: package.json missing)
- `node <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c5339199c0832d8aa42f0d063d42d9