### PR TITLE
Validate numeric inputs before saving

### DIFF
--- a/script.js
+++ b/script.js
@@ -117,38 +117,24 @@ document.addEventListener('DOMContentLoaded', async () => {
         const timestamp = document.getElementById('timestamp').value.trim();
         const notes = document.getElementById('notes').value;
 
-        const tempVal = document.getElementById('temperature').value.trim();
-        const sugarVal = document.getElementById('sugar').value.trim();
-        const phVal = document.getElementById('ph').value.trim();
-        const taVal = document.getElementById('ta').value.trim();
-
-        const temperature = tempVal === '' ? null : parseFloat(tempVal);
-        const sugar = sugarVal === '' ? null : parseFloat(sugarVal);
-        const ph = phVal === '' ? null : parseFloat(phVal);
-        const ta = taVal === '' ? null : parseFloat(taVal);
-
-        if (tempVal !== '' && !Number.isFinite(temperature)) {
-            alert('Please enter a valid temperature.');
-            return;
-        }
-        if (sugarVal !== '' && !Number.isFinite(sugar)) {
-            alert('Please enter a valid sugar reading.');
-            return;
-        }
-        if (phVal !== '' && !Number.isFinite(ph)) {
-            alert('Please enter a valid pH value.');
-            return;
-        }
-        if (taVal !== '' && !Number.isFinite(ta)) {
-            alert('Please enter a valid total acidity.');
-            return;
-        }
+        const rawValues = {
+            temperature: document.getElementById('temperature').value.trim(),
+            sugar: document.getElementById('sugar').value.trim(),
+            ph: document.getElementById('ph').value.trim(),
+            ta: document.getElementById('ta').value.trim(),
+        };
 
         const newReading = { timestamp, notes };
-        if (temperature !== null) newReading.temperature = temperature;
-        if (sugar !== null) newReading.sugar = sugar;
-        if (ph !== null) newReading.ph = ph;
-        if (ta !== null) newReading.ta = ta;
+
+        for (const [key, val] of Object.entries(rawValues)) {
+            if (val === '') continue;
+            const parsed = parseFloat(val);
+            if (Number.isNaN(parsed)) {
+                alert(`Please enter a valid ${key}.`);
+                return;
+            }
+            newReading[key] = parsed;
+        }
 
         const tankData = getTankData(currentTankId);
         tankData.push(newReading);


### PR DESCRIPTION
## Summary
- Parse numeric form inputs using `parseFloat`
- Skip blank fields and alert on invalid numbers
- Persist only validated numeric values in new readings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c535324618832da6ee36bcc94a173c