### PR TITLE
Sanitize imported data

### DIFF
--- a/script.js
+++ b/script.js
@@ -212,10 +212,24 @@ document.addEventListener('DOMContentLoaded', async () => {
                       imported = JSON.parse(e.target.result);
                   }
                   if (!Array.isArray(imported)) throw new Error('Invalid file format');
+
                   const tankData = getTankData(currentTankId);
-                  const merged = tankData.concat(imported);
-                  merged.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
-                  saveTankData(currentTankId, merged);
+                  const numericFields = ['temperature', 'sugar', 'ph', 'ta'];
+
+                  imported.forEach(entry => {
+                      numericFields.forEach(field => {
+                          if (entry[field] !== undefined && entry[field] !== '') {
+                              const num = parseFloat(entry[field]);
+                              if (!Number.isNaN(num)) {
+                                  entry[field] = num;
+                              }
+                          }
+                      });
+                      tankData.push(entry);
+                  });
+
+                  tankData.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+                  saveTankData(currentTankId, tankData);
                   renderLog();
                   alert('Import successful!');
               } catch (err) {


### PR DESCRIPTION
## Summary
- parse imported entries and coerce numeric fields to numbers before merging with existing tank data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5367ac6b8832db5006b4748e27024