### PR TITLE
Reset form when switching tanks

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,9 +11,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     const exportBtn = document.getElementById('exportBtn');
     const importBtn = document.getElementById('importBtn');
     const importFileInput = document.getElementById('importFile');
-    
+    const submitBtn = readingForm.querySelector('button[type="submit"]');
+
     let currentTankId = ''; // Variable to store the currently active tank ID
     let tanks = []; // Will hold the tank list loaded from JSON
+    let editingIndex = null; // Track index of reading being edited
 
     // ---- NEW: Function to populate the dropdown menu ----
     const populateTankSelector = () => {
@@ -36,8 +38,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         } else {
             tankDetailsP.textContent = '';
         }
-        
+
         renderLog(); // Load and display the log for the selected tank
+        readingForm.reset();
+        editingIndex = null;
+        submitBtn.textContent = 'Save Reading';
     };
 
     // Function to render the log entries in the table


### PR DESCRIPTION
## Summary
- Track `submitBtn` and `editingIndex` to manage edit state.
- After switching tanks, re-render logs, reset the form, clear edit index, and restore the submit button label.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c53679e1cc832db2a63916383aa999