### PR TITLE
Add editing and CSV/JSON import/export capabilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,9 +75,11 @@
 
         <section class="data-management">
             <h2>Data Management</h2>
-            <button id="exportBtn">Export</button>
+            <button id="exportJsonBtn">Export JSON</button>
+            <button id="exportCsvBtn">Export CSV</button>
             <input type="file" id="importFile" accept=".json,.csv" style="display: none;">
-            <button id="importBtn">Import</button>
+            <button id="importJsonBtn">Import JSON</button>
+            <button id="importCsvBtn">Import CSV</button>
         </section>
     </main>
 


### PR DESCRIPTION
## Summary
- Add dedicated JSON/CSV export and import buttons
- Implement editing of existing readings and rewrite submission logic
- Handle CSV/JSON import and export with explicit event handlers

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c53ac37070832d94ae342f7ee74975