### PR TITLE
Add overview overview table summarizing latest tank readings

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,23 @@
         <h1>Fermentation Log</h1>
     </header>
     <main>
+        <section class="overview">
+            <h2>Overview</h2>
+            <table id="overviewTable">
+                <thead>
+                    <tr>
+                        <th>Tank</th>
+                        <th>Date & Time</th>
+                        <th>Temp (°C)</th>
+                        <th>Sugar (Baumé)</th>
+                        <th>pH</th>
+                        <th>TA (g/L)</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody id="overviewTableBody"></tbody>
+            </table>
+        </section>
         <section class="tank-info">
             <h2>Select Tank</h2>
             <div class="info-inputs">


### PR DESCRIPTION
## Summary
- Create new Overview section listing each tank's latest reading
- Fetch tank logs on load, render latest data, and link to detailed logs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c53e639d98832da5869cd6574d5151