### PR TITLE
Add volume tracking and capacity comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,10 @@
                         <label for="ta">Total Acidity (g/L)</label>
                         <input type="number" id="ta" step="0.1" placeholder="e.g., 6.8">
                     </div>
+                    <div class="form-group">
+                        <label for="volume">Volume (L)</label>
+                        <input type="number" id="volume" step="0.1" placeholder="e.g., 1000">
+                    </div>
                     <div class="form-group full-width">
                         <label for="notes">Additions & Notes</label>
                         <textarea id="notes" rows="3" placeholder="e.g., Added 50g of Nutrient X"></textarea>
@@ -87,6 +91,7 @@
                         <th>Specific Gravity</th>
                         <th>pH</th>
                         <th>TA (g/L)</th>
+                        <th>Volume (L)</th>
                         <th>Notes / Additions</th>
                         <th>Actions</th>
                     </tr>


### PR DESCRIPTION
## Summary
- add volume input and column to log entries
- persist volume values in storage and import/export
- show tank capacity next to current volume for quick reference

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c53f89f5d8832d90947c9aa20f15f1