### PR TITLE
Add additive calculator for tank log

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,9 @@ Small client-side tool for recording fermentation readings for each tank.
 1. Select a tank using the dropdown.
 2. Click **Export** to download the tank's log. When prompted, choose JSON or CSV.
 3. To import, select the tank that should receive the data, click **Import**, and choose a JSON or CSV file.
-   The file's entries are merged into the tank's existing log sorted by timestamp.
+    The file's entries are merged into the tank's existing log sorted by timestamp.
+
+## Additive Calculator
+
+Use the **Additive Calculator** section to determine how much of an additive is required for a batch. Enter the batch volume and the desired dosage rate for nutrients, enzymes, SO₂ (KMS), bentonite, or tannins. The tool displays the calculated amount and can save the result as a note in the selected tank's log.
 

--- a/index.html
+++ b/index.html
@@ -80,6 +80,57 @@
             </form>
         </section>
 
+        <section class="calculator">
+            <h2>Additive Calculator</h2>
+            <p>Enter the batch volume and dosage rates. For g/hL rates, amount&nbsp;=&nbsp;volume&nbsp;×&nbsp;rate&nbsp;/&nbsp;100. For SO₂ (KMS) in mg/L, amount&nbsp;=&nbsp;volume&nbsp;×&nbsp;rate&nbsp;/&nbsp;1000.</p>
+            <div class="form-group">
+                <label for="calcVolume">Volume (L)</label>
+                <input type="number" id="calcVolume" step="0.1" placeholder="e.g., 1000">
+            </div>
+            <table class="calc-table">
+                <thead>
+                    <tr>
+                        <th>Additive</th>
+                        <th>Dosage Rate</th>
+                        <th>Amount (g)</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Nutrients (g/hL)</td>
+                        <td><input type="number" id="nutrientRate" step="0.01" placeholder="e.g., 20"></td>
+                        <td><span id="nutrientAmount"></span></td>
+                        <td><button type="button" id="nutrientSave">Save to Log</button></td>
+                    </tr>
+                    <tr>
+                        <td>Enzymes (g/hL)</td>
+                        <td><input type="number" id="enzymeRate" step="0.01" placeholder="e.g., 2"></td>
+                        <td><span id="enzymeAmount"></span></td>
+                        <td><button type="button" id="enzymeSave">Save to Log</button></td>
+                    </tr>
+                    <tr>
+                        <td>SO₂ (KMS) (mg/L)</td>
+                        <td><input type="number" id="kmsRate" step="1" placeholder="e.g., 50"></td>
+                        <td><span id="kmsAmount"></span></td>
+                        <td><button type="button" id="kmsSave">Save to Log</button></td>
+                    </tr>
+                    <tr>
+                        <td>Bentonite (g/hL)</td>
+                        <td><input type="number" id="bentoniteRate" step="0.01" placeholder="e.g., 10"></td>
+                        <td><span id="bentoniteAmount"></span></td>
+                        <td><button type="button" id="bentoniteSave">Save to Log</button></td>
+                    </tr>
+                    <tr>
+                        <td>Tannins (g/hL)</td>
+                        <td><input type="number" id="tanninRate" step="0.01" placeholder="e.g., 5"></td>
+                        <td><span id="tanninAmount"></span></td>
+                        <td><button type="button" id="tanninSave">Save to Log</button></td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+
         <section class="log-display">
             <h2>Log History for <span id="logTankId">...</span></h2>
             <table id="logTable">

--- a/script.js
+++ b/script.js
@@ -163,6 +163,91 @@ document.addEventListener('DOMContentLoaded', async () => {
         return Array.from(map.values()).sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
     };
 
+    // --- Additive Calculator ---
+    const calcVolumeInput = document.getElementById('calcVolume');
+    if (calcVolumeInput) {
+        const calcFields = [
+            {
+                name: 'Nutrients',
+                rateInput: document.getElementById('nutrientRate'),
+                resultSpan: document.getElementById('nutrientAmount'),
+                button: document.getElementById('nutrientSave'),
+                unit: 'g',
+                calc: (vol, rate) => vol * rate / 100
+            },
+            {
+                name: 'Enzymes',
+                rateInput: document.getElementById('enzymeRate'),
+                resultSpan: document.getElementById('enzymeAmount'),
+                button: document.getElementById('enzymeSave'),
+                unit: 'g',
+                calc: (vol, rate) => vol * rate / 100
+            },
+            {
+                name: 'SO₂ (KMS)',
+                rateInput: document.getElementById('kmsRate'),
+                resultSpan: document.getElementById('kmsAmount'),
+                button: document.getElementById('kmsSave'),
+                unit: 'g',
+                calc: (vol, rate) => vol * rate / 1000
+            },
+            {
+                name: 'Bentonite',
+                rateInput: document.getElementById('bentoniteRate'),
+                resultSpan: document.getElementById('bentoniteAmount'),
+                button: document.getElementById('bentoniteSave'),
+                unit: 'g',
+                calc: (vol, rate) => vol * rate / 100
+            },
+            {
+                name: 'Tannins',
+                rateInput: document.getElementById('tanninRate'),
+                resultSpan: document.getElementById('tanninAmount'),
+                button: document.getElementById('tanninSave'),
+                unit: 'g',
+                calc: (vol, rate) => vol * rate / 100
+            }
+        ];
+
+        const updateCalculator = () => {
+            const volume = parseFloat(calcVolumeInput.value);
+            calcFields.forEach(field => {
+                const rate = parseFloat(field.rateInput.value);
+                if (!Number.isNaN(volume) && !Number.isNaN(rate)) {
+                    const amount = field.calc(volume, rate);
+                    field.latestAmount = amount;
+                    field.resultSpan.textContent = amount.toFixed(2);
+                } else {
+                    field.latestAmount = null;
+                    field.resultSpan.textContent = '';
+                }
+            });
+        };
+
+        calcVolumeInput.addEventListener('input', updateCalculator);
+        calcFields.forEach(field => {
+            field.rateInput.addEventListener('input', updateCalculator);
+            field.button.addEventListener('click', () => {
+                if (!currentTankId) {
+                    alert('Please select a tank from the dropdown.');
+                    return;
+                }
+                if (field.latestAmount == null) {
+                    alert('Please enter volume and dosage rate first.');
+                    return;
+                }
+                const tankData = getTankData(currentTankId);
+                tankData.push({
+                    timestamp: new Date().toISOString(),
+                    notes: `${field.name}: ${field.latestAmount.toFixed(2)} ${field.unit}`
+                });
+                saveTankData(currentTankId, tankData);
+                renderLog();
+                renderOverview();
+            });
+        });
+    }
+
     // --- Event Listeners ---
 
     // NEW: Listen for changes on the dropdown menu


### PR DESCRIPTION
## Summary
- add an additive calculator section for nutrients, enzymes, SO₂, bentonite and tannins
- compute dosages from batch volume and dosage rates
- optionally save calculated amounts as notes in the selected tank log

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5408d2edc832d862e85c9b687d068