### PR TITLE
Add collapsible overview and filter inactive tanks

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,10 @@
 <body>
     <header>
         <h1>Fermentation Log</h1>
+        <button id="toggleOverviewBtn">Show Overview</button>
     </header>
     <main>
-        <section class="overview">
+        <section class="overview hidden">
             <h2>Overview</h2>
             <table id="overviewTable">
                 <thead>

--- a/script.js
+++ b/script.js
@@ -15,6 +15,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const importFileInput = document.getElementById('importFile');
     const submitBtn = readingForm.querySelector('button[type="submit"]');
     const overviewTableBody = document.getElementById('overviewTableBody');
+    const toggleOverviewBtn = document.getElementById('toggleOverviewBtn');
+    const overviewSection = document.querySelector('.overview');
 
     let currentTankId = ''; // Variable to store the currently active tank ID
     let tanks = []; // Will hold the tank list loaded from JSON
@@ -108,6 +110,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         overviewTableBody.innerHTML = '';
         tanks.forEach(tank => {
             const tankData = getTankData(tank.id);
+            if (tankData.length === 0) {
+                return; // Skip tanks with no readings
+            }
             let latest = null;
             if (tankData.length > 0) {
                 latest = tankData.reduce((a, b) => new Date(a.timestamp) > new Date(b.timestamp) ? a : b);
@@ -427,7 +432,15 @@ document.addEventListener('DOMContentLoaded', async () => {
           event.target.value = '';
           importFormat = null;
       });
-    
+
+      toggleOverviewBtn.addEventListener('click', () => {
+          const isHidden = overviewSection.classList.toggle('hidden');
+          toggleOverviewBtn.textContent = isHidden ? 'Show Overview' : 'Hide Overview';
+          if (!isHidden) {
+              overviewSection.scrollIntoView({ behavior: 'smooth' });
+          }
+      });
+
     // --- Initial Setup ---
     try {
         const response = await fetch('tanks.json');

--- a/style.css
+++ b/style.css
@@ -33,6 +33,11 @@ section {
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
+/* Utility class to hide elements */
+.hidden {
+    display: none;
+}
+
 h2 {
     color: #4a6da7;
     border-bottom: 2px solid #eeeeee;


### PR DESCRIPTION
## Summary
- Add a toggle button to reveal or hide the overview table
- Hide the overview by default and scroll to it when opened
- Only display tanks with existing readings in the overview

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c541a7c0ac832d9b65d2caf5870a97