### PR TITLE
Add refractometer conversions and bidirectional sugar units

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,13 +85,66 @@ class FermentationTracker {
         });
         
         // Sugar conversion
+        let updatingSugar = false;
+
+        const updateFromBaume = (baume) => {
+            const gl = FermentationCalculations.baumeToGL(baume);
+            ui.sugarGL.value = gl.toFixed(1);
+            if (ui.brix) {
+                ui.brix.value = FermentationCalculations.glToBrix(gl).toFixed(1);
+            }
+        };
+
+        const updateFromGL = (gl) => {
+            ui.sugar.value = FermentationCalculations.glToBaume(gl).toFixed(1);
+            if (ui.brix) {
+                ui.brix.value = FermentationCalculations.glToBrix(gl).toFixed(1);
+            }
+        };
+
+        const updateFromBrix = (brix) => {
+            const gl = FermentationCalculations.brixToGL(brix);
+            ui.sugarGL.value = gl.toFixed(1);
+            ui.sugar.value = FermentationCalculations.glToBaume(gl).toFixed(1);
+        };
+
         ui.sugar?.addEventListener('input', (e) => {
+            if (updatingSugar) return;
             const baume = parseFloat(e.target.value);
+            updatingSugar = true;
             if (!isNaN(baume)) {
-                ui.sugarGL.value = FermentationCalculations.baumeToGL(baume).toFixed(1);
+                updateFromBaume(baume);
             } else {
                 ui.sugarGL.value = '';
+                if (ui.brix) ui.brix.value = '';
             }
+            updatingSugar = false;
+        });
+
+        ui.sugarGL?.addEventListener('input', (e) => {
+            if (updatingSugar) return;
+            const gl = parseFloat(e.target.value);
+            updatingSugar = true;
+            if (!isNaN(gl)) {
+                updateFromGL(gl);
+            } else {
+                ui.sugar.value = '';
+                if (ui.brix) ui.brix.value = '';
+            }
+            updatingSugar = false;
+        });
+
+        ui.brix?.addEventListener('input', (e) => {
+            if (updatingSugar) return;
+            const brix = parseFloat(e.target.value);
+            updatingSugar = true;
+            if (!isNaN(brix)) {
+                updateFromBrix(brix);
+            } else {
+                ui.sugar.value = '';
+                ui.sugarGL.value = '';
+            }
+            updatingSugar = false;
         });
         
         // Log table actions

--- a/calculations.js
+++ b/calculations.js
@@ -2,8 +2,12 @@
 const FermentationCalculations = {
     // Unit conversions
     baumeToGL: (baume) => baume * 18,
-    
+
     glToBaume: (gl) => gl / 18,
+
+    brixToGL: (brix) => brix * 10,
+
+    glToBrix: (gl) => gl / 10,
     
     // Additive calculations
     calculateNutrients: (volume, rateGHL) => volume * rateGHL / 100,

--- a/index.html
+++ b/index.html
@@ -64,9 +64,13 @@
                         <input type="number" id="temperature" step="0.1" placeholder="e.g., 15.5">
                     </div>
                     <div class="form-group">
+                        <label for="brix">Refractometer (°Bx)</label>
+                        <input type="number" id="brix" step="0.1" placeholder="e.g., 20.5">
+                    </div>
+                    <div class="form-group">
                         <label for="sugar">Sugar (Baumé)</label>
                         <input type="number" id="sugar" step="0.1" placeholder="e.g., 12.5">
-                        <input type="number" id="sugarGL" placeholder="g/L" readonly>
+                        <input type="number" id="sugarGL" placeholder="g/L">
                     </div>
                     <div class="form-group">
                         <label for="sg">Specific Gravity</label>

--- a/uiManager.js
+++ b/uiManager.js
@@ -25,6 +25,7 @@ class UIManager {
             temperature: document.getElementById('temperature'),
             sugar: document.getElementById('sugar'),
             sugarGL: document.getElementById('sugarGL'),
+            brix: document.getElementById('brix'),
             sg: document.getElementById('sg'),
             ph: document.getElementById('ph'),
             ta: document.getElementById('ta'),
@@ -279,7 +280,11 @@ class UIManager {
         
         // Update sugar conversion
         if (reading.sugar) {
-            this.elements.sugarGL.value = FermentationCalculations.baumeToGL(reading.sugar).toFixed(1);
+            const gl = FermentationCalculations.baumeToGL(reading.sugar);
+            this.elements.sugarGL.value = gl.toFixed(1);
+            if (this.elements.brix) {
+                this.elements.brix.value = FermentationCalculations.glToBrix(gl).toFixed(1);
+            }
         }
     }
 
@@ -304,6 +309,7 @@ class UIManager {
     resetForm() {
         this.elements.readingForm.reset();
         this.elements.sugarGL.value = '';
+        if (this.elements.brix) this.elements.brix.value = '';
         this.editingIndex = null;
         if (this.elements.submitBtn) {
             this.elements.submitBtn.textContent = 'Save Reading';


### PR DESCRIPTION
## Summary
- convert between Baumé, g/L, and Brix units in calculations
- support refractometer readings and editable g/L field on the form
- keep UI manager in sync with new sugar conversions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6c4666c84832da05cb9bdfefc1d9a