### PR TITLE
Normalize datetime inputs for log entries

### DIFF
--- a/app.js
+++ b/app.js
@@ -408,7 +408,7 @@ class FermentationTracker {
                 }
                 
                 this.dataManager.addReading(tankId, {
-                    timestamp: new Date().toISOString(),
+                    timestamp: formatForDateTimeInput(new Date()),
                     notes: `${calc.name}: ${calc.latestAmount.toFixed(2)} g`
                 });
                 

--- a/uiManager.js
+++ b/uiManager.js
@@ -269,7 +269,8 @@ class UIManager {
     }
 
     loadFormData(reading) {
-        this.elements.timestamp.value = reading.timestamp;
+        const formattedTimestamp = formatForDateTimeInput(reading.timestamp);
+        this.elements.timestamp.value = formattedTimestamp || '';
         this.elements.temperature.value = reading.temperature ?? '';
         this.elements.sugar.value = reading.sugar ?? '';
         this.elements.sg.value = reading.sg ?? '';


### PR DESCRIPTION
## Summary
- add a reusable `formatForDateTimeInput` helper to produce datetime-local formatted strings that account for local timezones
- use the helper when logging additive calculator entries and when loading existing readings into the form
- normalize imported readings' timestamps during data merges so legacy data stays compatible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d250bea188832d8d7595bf61b54b5e