### PR TITLE
Fix PWA asset paths for GitHub Pages

### DIFF
--- a/enhanced-dashboard.html
+++ b/enhanced-dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Winery Management System</title>
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="manifest.json">
     <link rel="stylesheet" href="enhanced-styles.css">
 </head>
 <body>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,8 @@
 {
   "name": "VineTrack Pro",
   "short_name": "VineTrack",
-  "start_url": "/index.html",
+  "start_url": "./index.html",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#722f37",

--- a/pwa.js
+++ b/pwa.js
@@ -18,7 +18,7 @@ class PWAManager {
             return;
         }
         try {
-            const registration = await navigator.serviceWorker.register('/sw.js');
+            const registration = await navigator.serviceWorker.register('sw.js', { scope: './' });
             this.swRegistration = registration;
             registration.addEventListener('updatefound', () => {
                 const newWorker = registration.installing;

--- a/sw.js
+++ b/sw.js
@@ -1,21 +1,25 @@
 const CACHE_NAME = 'winery-v2.0';
-const urlsToCache = [
-    '/',
-    '/index.html',
-    '/style.css',
-    '/enhanced-styles.css',
-    '/enhanced-dashboard.html',
-    '/batchManager.js',
-    '/labIntegration.js',
-    '/productionPlanner.js',
-    '/complianceManager.js',
-    '/aiAnalytics.js',
-    '/apiIntegration.js',
-    '/pwa.js',
-    '/app.js',
-    '/tanks.json',
-    '/manifest.json'
+const assetPaths = [
+    'index.html',
+    'style.css',
+    'enhanced-styles.css',
+    'enhanced-dashboard.html',
+    'batchManager.js',
+    'labIntegration.js',
+    'productionPlanner.js',
+    'complianceManager.js',
+    'aiAnalytics.js',
+    'apiIntegration.js',
+    'pwa.js',
+    'app.js',
+    'tanks.json',
+    'manifest.json'
 ];
+
+const baseScope = (self.registration && self.registration.scope)
+    ? self.registration.scope
+    : new URL('./', self.location.href).toString();
+const urlsToCache = assetPaths.map(path => new URL(path, baseScope).toString());
 
 self.addEventListener('install', event => {
     event.waitUntil(


### PR DESCRIPTION
## Summary
- register the service worker with a repo-relative scope so GitHub Pages loads sw.js from the project directory
- build the service worker cache list relative to its scope to avoid leading-slash requests on GitHub Pages
- update the manifest start URL and dashboard manifest link to use repo-relative paths for correct PWA launching

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d2da4f8ac4832d91a36e8cb25fef6f