### PR TITLE
Enable interactive dashboard views and notifications

### DIFF
--- a/enhanced-app.js
+++ b/enhanced-app.js
@@ -16,18 +16,29 @@ class EnhancedDashboardApp {
         this.scanResultElement = null;
         this.lastScanAttempt = 0;
         this.tempChart = null;
+        this.currentView = 'dashboard';
+        this.cellar3DEnabled = false;
+        this.notifications = [];
+        this.notificationsOpen = false;
+        this.handleDocumentClick = this.handleDocumentClick.bind(this);
+        this.handleEscape = this.handleEscape.bind(this);
     }
 
     async init() {
         await this.loadTanks();
         this.populateQuickAddSelector();
-        this.renderKPIs();
-        this.renderCellarMap();
-        this.renderTemperatureChart();
-        this.renderFermentationProgress();
-        this.renderActivityFeed();
-        this.renderTimeline();
+        this.bindNavigation();
         this.bindQuickAddForm();
+        this.bindNotificationPanel();
+        this.bindGlobalEvents();
+        this.updateNotifications();
+        this.renderTankOverview();
+        this.renderBatchOverview();
+        this.renderLabOverview();
+        this.renderProductionSchedule();
+        this.renderAnalyticsSummary();
+        this.renderSettingsPanel();
+        this.switchView(this.currentView);
     }
 
     async loadTanks() {
@@ -50,6 +61,51 @@ class EnhancedDashboardApp {
             option.textContent = `${tank.id} (${tank.capacity} L)`;
             select.appendChild(option);
         });
+    }
+
+    bindNavigation() {
+        const navItems = document.querySelectorAll('.nav-menu .nav-item[data-view]');
+        navItems.forEach(item => {
+            item.addEventListener('click', () => {
+                const targetView = item.dataset.view;
+                if (targetView) {
+                    this.switchView(targetView);
+                }
+            });
+        });
+    }
+
+    bindNotificationPanel() {
+        const panel = document.getElementById('notificationPanel');
+        if (panel) {
+            panel.addEventListener('click', (event) => event.stopPropagation());
+        }
+    }
+
+    bindGlobalEvents() {
+        document.addEventListener('click', this.handleDocumentClick);
+        document.addEventListener('keydown', this.handleEscape);
+    }
+
+    handleDocumentClick(event) {
+        if (!this.notificationsOpen) {
+            return;
+        }
+        const panel = document.getElementById('notificationPanel');
+        const button = document.querySelector('.btn-notifications');
+        if (!panel || !button) {
+            return;
+        }
+        if (panel.contains(event.target) || button.contains(event.target)) {
+            return;
+        }
+        this.toggleNotifications(false);
+    }
+
+    handleEscape(event) {
+        if (event.key === 'Escape' && this.notificationsOpen) {
+            this.toggleNotifications(false);
+        }
     }
 
     bindQuickAddForm() {
@@ -79,6 +135,10 @@ class EnhancedDashboardApp {
             this.renderTemperatureChart();
             this.renderFermentationProgress();
             this.renderActivityFeed();
+            this.renderTankOverview();
+            this.renderBatchOverview();
+            this.renderAnalyticsSummary();
+            this.updateNotifications();
         });
     }
 
@@ -112,26 +172,673 @@ class EnhancedDashboardApp {
         }
     }
 
+    switchView(view) {
+        const target = view || 'dashboard';
+        this.currentView = target;
+
+        const navItems = document.querySelectorAll('.nav-menu .nav-item[data-view]');
+        navItems.forEach(item => {
+            const isActive = item.dataset.view === target;
+            item.classList.toggle('active', isActive);
+            if (isActive) {
+                item.setAttribute('aria-current', 'page');
+            } else {
+                item.removeAttribute('aria-current');
+            }
+        });
+
+        let matched = false;
+        const panels = document.querySelectorAll('.view-panel[data-view]');
+        panels.forEach(panel => {
+            const isMatch = panel.dataset.view === target;
+            panel.classList.toggle('active', isMatch);
+            panel.setAttribute('aria-hidden', isMatch ? 'false' : 'true');
+            if (isMatch) {
+                matched = true;
+            }
+        });
+
+        if (!matched) {
+            return;
+        }
+
+        switch (target) {
+            case 'dashboard':
+                this.renderKPIs();
+                this.renderCellarMap();
+                this.renderTemperatureChart();
+                this.renderFermentationProgress();
+                this.renderActivityFeed();
+                this.renderTimeline();
+                break;
+            case 'tanks':
+                this.renderTankOverview();
+                break;
+            case 'batches':
+                this.renderBatchOverview();
+                break;
+            case 'laboratory':
+                this.renderLabOverview();
+                break;
+            case 'production':
+                this.renderProductionSchedule();
+                break;
+            case 'analytics':
+                this.renderAnalyticsSummary();
+                break;
+            case 'settings':
+                this.renderSettingsPanel();
+                break;
+            default:
+                break;
+        }
+
+        this.toggleNotifications(false);
+    }
+
     renderCellarMap() {
-        if (!this.productionPlanner) return;
-        const map = this.productionPlanner.generateCellarMap();
         const container = document.getElementById('cellarVisualization');
         if (!container) return;
+        const toggleButton = document.querySelector('[data-action="toggle-3d"]');
+        if (toggleButton) {
+            toggleButton.textContent = this.cellar3DEnabled ? '2D View' : '3D View';
+            toggleButton.setAttribute('aria-pressed', String(this.cellar3DEnabled));
+        }
+
         container.innerHTML = '';
+        if (this.cellar3DEnabled) {
+            this.renderCellar3D(container);
+            return;
+        }
+
+        const map = this.productionPlanner ? this.productionPlanner.generateCellarMap() : { tanks: [] };
+        const plannerTanks = Array.isArray(map.tanks) && map.tanks.length > 0 ? map.tanks : [];
+        const tanks = plannerTanks.length ? plannerTanks : this.tanks.map(tank => ({
+            id: tank.id,
+            location: tank.location ?? 'Cellar',
+            fillLevel: 0,
+            temperature: null,
+            capacity: tank.capacity
+        }));
+
+        if (!tanks.length) {
+            const empty = document.createElement('div');
+            empty.className = 'empty-state glass-card';
+            empty.innerHTML = '<h3>No tanks available</h3><p>Add tanks to visualize your cellar layout.</p>';
+            container.appendChild(empty);
+            return;
+        }
+
         const grid = document.createElement('div');
         grid.className = 'tank-grid';
-        map.tanks.forEach(tank => {
+        tanks.forEach(tank => {
             const card = document.createElement('div');
             card.className = 'glass-card';
+            const fillLevel = typeof tank.fillLevel === 'number' ? tank.fillLevel : 0;
             card.innerHTML = `
                 <h3>${tank.id}</h3>
-                <p>Location: ${tank.location}</p>
-                <p>Fill Level: ${tank.fillLevel.toFixed(1)}%</p>
-                <p>Temperature: ${tank.temperature ?? 'N/A'}°C</p>
+                <p>Location: ${tank.location ?? '—'}</p>
+                <p>Fill Level: ${fillLevel.toFixed(1)}%</p>
+                <p>Temperature: ${tank.temperature != null ? `${tank.temperature}°C` : 'N/A'}</p>
             `;
             grid.appendChild(card);
         });
         container.appendChild(grid);
+    }
+
+    renderCellar3D(container) {
+        const stage = document.createElement('div');
+        stage.className = 'cellar-3d';
+        const tanks = this.tanks.length ? this.tanks : (this.productionPlanner?.resources?.tanks ?? []);
+
+        if (!tanks.length) {
+            const empty = document.createElement('div');
+            empty.className = 'empty-state glass-card';
+            empty.innerHTML = '<h3>No tanks to display</h3><p>Add tanks to experience the 3D cellar view.</p>';
+            container.appendChild(empty);
+            return;
+        }
+
+        const batchesByTank = new Map();
+        if (this.batchManager) {
+            this.batchManager.getAllBatches().forEach(batch => {
+                if (batch.currentTank) {
+                    batchesByTank.set(batch.currentTank, batch);
+                }
+            });
+        }
+
+        tanks.slice(0, 12).forEach(tank => {
+            const card = document.createElement('div');
+            card.className = 'cellar-3d__tank glass-card';
+            const assigned = batchesByTank.get(tank.id);
+            const capacity = Number(tank.capacity ?? 0);
+            const currentVolume = Number.isFinite(assigned?.currentVolume)
+                ? Number(assigned.currentVolume)
+                : Number.isFinite(assigned?.initialVolume)
+                    ? Number(assigned.initialVolume)
+                    : null;
+            const fillPercent = capacity > 0 && currentVolume != null
+                ? Math.max(0, Math.min(100, Math.round((currentVolume / capacity) * 100)))
+                : 0;
+
+            card.innerHTML = `
+                <div>
+                    <h3>${tank.id}</h3>
+                    <p class="cellar-3d__meta">${assigned ? `${assigned.variety ?? 'Blend'} • ${assigned.status ?? 'active'}` : (tank.location ?? 'Available')}</p>
+                </div>
+                <div class="cellar-3d__level">
+                    <div class="cellar-3d__level-fill" style="height:${fillPercent}%"></div>
+                </div>
+                <p class="cellar-3d__meta">${capacity ? `${capacity.toLocaleString()} L capacity` : ''}</p>
+            `;
+            stage.appendChild(card);
+        });
+
+        container.appendChild(stage);
+    }
+
+    renderTankOverview() {
+        const container = document.getElementById('tankOverviewList');
+        const emptyState = document.getElementById('tanksEmptyState');
+        if (!container) {
+            return;
+        }
+        container.innerHTML = '';
+
+        if (!Array.isArray(this.tanks) || this.tanks.length === 0) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        this.toggleEmptyState(emptyState, false);
+
+        const batchesByTank = new Map();
+        if (this.batchManager) {
+            this.batchManager.getAllBatches().forEach(batch => {
+                if (batch.currentTank) {
+                    batchesByTank.set(batch.currentTank, batch);
+                }
+            });
+        }
+
+        this.tanks.forEach(tank => {
+            const card = document.createElement('article');
+            card.className = 'glass-card tank-overview-card';
+            const assigned = batchesByTank.get(tank.id);
+            const capacity = Number(tank.capacity ?? 0);
+            const currentVolume = Number.isFinite(assigned?.currentVolume)
+                ? Number(assigned.currentVolume)
+                : Number.isFinite(assigned?.initialVolume)
+                    ? Number(assigned.initialVolume)
+                    : null;
+            const latest = this.dataManager ? this.dataManager.getLatestReading(tank.id) : null;
+            const fillPercent = capacity > 0 && currentVolume != null
+                ? Math.max(0, Math.min(100, Math.round((currentVolume / capacity) * 100)))
+                : null;
+
+            const capacityText = this.formatNumber(capacity);
+            const volumeText = currentVolume != null ? this.formatNumber(currentVolume) : null;
+            const temperatureText = typeof latest?.temperature === 'number'
+                ? `${latest.temperature}°C`
+                : latest?.temperature != null
+                    ? `${latest.temperature}`
+                    : '—';
+            const sugarValue = latest?.sugar;
+            const sugarText = sugarValue != null ? `${sugarValue}` : '—';
+
+            const metrics = [
+                { label: 'Capacity', value: capacityText ? `${capacityText} L` : '—' },
+                { label: 'Volume', value: volumeText ? `${volumeText} L` : '—' },
+                { label: 'Temperature', value: temperatureText },
+                { label: 'Sugar', value: sugarText }
+            ];
+
+            card.innerHTML = `
+                <header>
+                    <h3>${tank.id}</h3>
+                    <span class="status-pill ${assigned ? 'status-active' : 'status-idle'}">${assigned ? 'Active' : 'Available'}</span>
+                </header>
+                <p class="tank-details">${tank.description || 'No description provided.'}</p>
+                <p class="tank-current-batch">Current batch: ${assigned ? `${assigned.variety ?? 'Blend'} ${assigned.vintage ?? ''}`.trim() || assigned.id : 'None assigned'}</p>
+                <dl class="metric-list">
+                    ${metrics.map(metric => `<div><dt>${metric.label}</dt><dd>${metric.value}</dd></div>`).join('')}
+                </dl>
+                <p class="tank-last-reading">Last reading: ${latest?.timestamp ? this.formatDate(latest.timestamp) : 'No readings yet'}</p>
+                ${fillPercent != null ? `<div class="progress"><div class="progress-bar" style="width:${fillPercent}%"></div></div><p class="progress-label">${fillPercent}% full</p>` : ''}
+            `;
+
+            container.appendChild(card);
+        });
+    }
+
+    renderBatchOverview() {
+        const container = document.getElementById('batchOverviewList');
+        const emptyState = document.getElementById('batchesEmptyState');
+        if (!container) {
+            return;
+        }
+        container.innerHTML = '';
+        const batches = this.batchManager ? this.batchManager.getAllBatches() : [];
+
+        if (!batches.length) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        this.toggleEmptyState(emptyState, false);
+
+        batches.forEach(batch => {
+            const card = document.createElement('article');
+            card.className = 'glass-card batch-overview-card';
+            const status = (batch.status ?? 'active').toLowerCase();
+            let statusClass = 'status-idle';
+            if (status === 'active') {
+                statusClass = 'status-active';
+            } else if (status === 'completed' || status === 'bottled') {
+                statusClass = 'status-success';
+            } else if (status === 'at-risk' || status === 'hold') {
+                statusClass = 'status-warning';
+            }
+
+            const labCount = batch.labResults?.length ?? 0;
+            const historyCount = batch.history?.length ?? 0;
+            const volumeNumber = Number.isFinite(batch.currentVolume) ? Number(batch.currentVolume) : null;
+            const currentVolume = volumeNumber != null
+                ? `${this.formatNumber(volumeNumber) ?? volumeNumber} L`
+                : '—';
+
+            card.innerHTML = `
+                <header>
+                    <h3>${batch.variety ?? 'Batch'} ${batch.vintage ?? ''}</h3>
+                    <span class="status-pill ${statusClass}">${(batch.status ?? 'ACTIVE').toUpperCase()}</span>
+                </header>
+                <p>Batch ID: ${batch.id}</p>
+                <dl class="metric-list">
+                    <div><dt>Volume</dt><dd>${currentVolume}</dd></div>
+                    <div><dt>Tank</dt><dd>${batch.currentTank ?? 'Unassigned'}</dd></div>
+                    <div><dt>Lab Tests</dt><dd>${labCount}</dd></div>
+                    <div><dt>History Events</dt><dd>${historyCount}</dd></div>
+                </dl>
+                <footer>Last updated: ${this.formatDate(batch.history?.[historyCount - 1]?.timestamp ?? batch.createdAt)}</footer>
+            `;
+
+            container.appendChild(card);
+        });
+    }
+
+    renderLabOverview() {
+        const container = document.getElementById('labResultsList');
+        const emptyState = document.getElementById('labEmptyState');
+        if (!container) {
+            return;
+        }
+        container.innerHTML = '';
+
+        if (!this.batchManager) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        const results = this.batchManager.getAllBatches()
+            .map(batch => {
+                const labResults = Array.isArray(batch.labResults) ? [...batch.labResults] : [];
+                if (!labResults.length) {
+                    return null;
+                }
+                const sorted = labResults.sort((a, b) => new Date(b.timestamp ?? b.date ?? 0) - new Date(a.timestamp ?? a.date ?? 0));
+                return { batch, result: sorted[0] };
+            })
+            .filter(Boolean);
+
+        if (!results.length) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        this.toggleEmptyState(emptyState, false);
+
+        results.slice(0, 6).forEach(entry => {
+            const { batch, result } = entry;
+            const quality = result.qualityScore?.score ?? result.qualityScore ?? batch.qualityScore ?? null;
+            const metrics = [
+                { label: 'Alcohol', value: result.alcohol != null ? `${result.alcohol}%` : '—' },
+                { label: 'pH', value: result.pH ?? result.ph ?? '—' },
+                { label: 'TA', value: result.totalAcidity ?? result.ta ?? '—' },
+                { label: 'VA', value: result.volatileAcidity ?? result.va ?? '—' }
+            ];
+
+            const card = document.createElement('article');
+            card.className = 'glass-card lab-overview-card';
+            card.innerHTML = `
+                <header>
+                    <h3>${batch.variety ?? 'Batch'} ${batch.vintage ?? ''}</h3>
+                    ${quality != null ? `<span class="status-pill status-active">Score ${quality}</span>` : ''}
+                </header>
+                <p>Sample ID: ${result.sampleId ?? result.id ?? 'N/A'}</p>
+                <dl class="metric-list">
+                    ${metrics.map(metric => `<div><dt>${metric.label}</dt><dd>${metric.value}</dd></div>`).join('')}
+                </dl>
+                <footer>Result date: ${this.formatDate(result.timestamp ?? result.date)}</footer>
+            `;
+            container.appendChild(card);
+        });
+    }
+
+    renderProductionSchedule() {
+        const container = document.getElementById('productionSchedule');
+        const emptyState = document.getElementById('productionEmptyState');
+        if (!container) {
+            return;
+        }
+        container.innerHTML = '';
+
+        if (!this.productionPlanner) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        const plan = this.productionPlanner.createProductionPlan(new Date().getFullYear());
+        if (!plan?.phases?.length) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        this.toggleEmptyState(emptyState, false);
+
+        plan.phases.forEach(phase => {
+            const card = document.createElement('article');
+            card.className = 'glass-card production-card';
+            card.innerHTML = `
+                <header>
+                    <h3>${phase.name}</h3>
+                    <span class="status-pill status-planned">${(phase.status ?? 'planned').toUpperCase()}</span>
+                </header>
+                <p>${this.formatDate(phase.startDate)} – ${this.formatDate(phase.endDate)}</p>
+                <ul>
+                    ${(phase.resources ?? []).map(resource => {
+                        if (resource.tankId) return `<li>Tank ${resource.tankId}</li>`;
+                        if (resource.barrelId) return `<li>Barrel ${resource.barrelId}</li>`;
+                        if (resource.crewId) return `<li>${resource.crewId}</li>`;
+                        if (resource.role) return `<li>${resource.role}</li>`;
+                        return '';
+                    }).join('')}
+                </ul>
+            `;
+            container.appendChild(card);
+        });
+
+        if (plan.optimization?.suggestions?.length) {
+            const summary = document.createElement('article');
+            summary.className = 'glass-card production-card';
+            summary.innerHTML = `
+                <header>
+                    <h3>Optimization Insights</h3>
+                    <span class="status-pill status-active">Utilization</span>
+                </header>
+                <ul class="suggestions-list">
+                    ${plan.optimization.suggestions.map(suggestion => `<li>${suggestion}</li>`).join('')}
+                </ul>
+                <footer>Crews: ${Math.round(plan.optimization.resourceUtilization.crews)}% • Tanks: ${Math.round(plan.optimization.resourceUtilization.tanks)}% • Barrels: ${Math.round(plan.optimization.resourceUtilization.barrels)}%</footer>
+            `;
+            container.appendChild(summary);
+        }
+    }
+
+    renderAnalyticsSummary() {
+        const container = document.getElementById('analyticsSummary');
+        const emptyState = document.getElementById('analyticsEmptyState');
+        if (!container) {
+            return;
+        }
+        container.innerHTML = '';
+
+        if (!this.aiAnalytics || !this.dataManager || !this.tanks.length) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        const cards = [];
+        this.tanks.slice(0, 6).forEach(tank => {
+            const prediction = this.aiAnalytics.predictFermentationCompletion(tank.id, this.dataManager);
+            if (!prediction) {
+                return;
+            }
+            const risks = Array.isArray(prediction.riskFactors) && prediction.riskFactors.length
+                ? prediction.riskFactors
+                : ['No critical risks detected'];
+            const recommendations = Array.isArray(prediction.recommendations) ? prediction.recommendations : [];
+
+            const card = document.createElement('article');
+            card.className = 'glass-card analytics-card';
+            card.innerHTML = `
+                <header>
+                    <h3>${tank.id}</h3>
+                    <span class="status-pill ${prediction.daysRemaining > 14 ? 'status-warning' : 'status-active'}">${prediction.daysRemaining} days remaining</span>
+                </header>
+                <p>Confidence: ${(prediction.confidence * 100).toFixed(0)}%</p>
+                <ul>
+                    ${risks.map(risk => `<li>${risk}</li>`).join('')}
+                </ul>
+                <footer>${recommendations.length ? (recommendations[0].action ?? recommendations[0]) : 'Monitoring stable fermentation.'}</footer>
+            `;
+            cards.push(card);
+        });
+
+        if (!cards.length) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        this.toggleEmptyState(emptyState, false);
+        cards.forEach(card => container.appendChild(card));
+    }
+
+    renderSettingsPanel() {
+        const container = document.getElementById('settingsPanel');
+        if (!container) {
+            return;
+        }
+        container.innerHTML = '';
+
+        const features = [
+            {
+                name: 'Offline Sync',
+                description: 'Capture readings without connectivity and sync automatically.',
+                active: !!this.pwaManager,
+                detail: this.pwaManager?.backgroundSyncSupported
+                    ? 'Background sync ready'
+                    : 'Using local queue until connection is restored',
+                statusClass: this.pwaManager ? 'status-active' : 'status-idle'
+            },
+            {
+                name: 'Barcode Scanner',
+                description: 'Use your device camera to scan tank QR codes.',
+                active: !!this.pwaManager?.barcodeDetector,
+                detail: this.pwaManager?.barcodeDetector
+                    ? 'BarcodeDetector API available'
+                    : 'Detector not supported in this browser',
+                statusClass: this.pwaManager?.barcodeDetector ? 'status-active' : 'status-warning'
+            },
+            {
+                name: 'ERP Integration',
+                description: 'Sync inventory and production data with ERP systems.',
+                active: !!this.apiIntegration,
+                detail: this.apiIntegration ? 'Endpoints configured' : 'Integration not connected',
+                statusClass: this.apiIntegration ? 'status-active' : 'status-idle'
+            },
+            {
+                name: 'AI Analytics',
+                description: 'Predict fermentation completion and highlight risks.',
+                active: !!this.aiAnalytics,
+                detail: this.aiAnalytics ? 'Model loaded' : 'Analytics module unavailable',
+                statusClass: this.aiAnalytics ? 'status-active' : 'status-warning'
+            }
+        ];
+
+        features.forEach(feature => {
+            const card = document.createElement('article');
+            card.className = 'glass-card settings-card';
+            card.innerHTML = `
+                <header>
+                    <h3>${feature.name}</h3>
+                    <span class="status-pill ${feature.statusClass}">${feature.active ? 'Enabled' : 'Unavailable'}</span>
+                </header>
+                <p>${feature.description}</p>
+                <footer>${feature.detail}</footer>
+            `;
+            container.appendChild(card);
+        });
+    }
+
+    toggleEmptyState(element, show) {
+        if (!element) {
+            return;
+        }
+        element.hidden = !show;
+        element.setAttribute('aria-hidden', show ? 'false' : 'true');
+    }
+
+    formatNumber(value) {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return value.toLocaleString();
+        }
+        if (typeof value === 'string' && value.trim() !== '' && !Number.isNaN(Number(value))) {
+            return Number(value).toLocaleString();
+        }
+        return null;
+    }
+
+    formatDate(value) {
+        if (!value) {
+            return '—';
+        }
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return value;
+        }
+        return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+    }
+
+    buildNotificationData() {
+        const notifications = [];
+        const now = new Date();
+
+        if (!this.tanks.length) {
+            notifications.push({
+                type: 'action',
+                message: 'Add tanks to begin monitoring your cellar.',
+                detail: 'Import a layout or create tanks from the Tanks view.',
+                time: 'Just now'
+            });
+        } else if (this.dataManager) {
+            const stale = this.tanks.filter(tank => {
+                const latest = this.dataManager.getLatestReading(tank.id);
+                if (!latest || !latest.timestamp) {
+                    return true;
+                }
+                const age = now - new Date(latest.timestamp);
+                return Number.isFinite(age) && age > 1000 * 60 * 60 * 24 * 2;
+            });
+            if (stale.length) {
+                notifications.push({
+                    type: 'warning',
+                    message: `${stale.length} tank${stale.length === 1 ? '' : 's'} need new readings.`,
+                    detail: 'Capture temperature and sugar updates to keep analytics accurate.',
+                    time: 'Today'
+                });
+            }
+        }
+
+        const batches = this.batchManager ? this.batchManager.getAllBatches() : [];
+        if (batches.length) {
+            const active = batches.filter(batch => (batch.status ?? 'active').toLowerCase() === 'active');
+            if (active.length) {
+                notifications.push({
+                    type: 'info',
+                    message: `${active.length} active fermentation${active.length === 1 ? '' : 's'} in progress.`,
+                    detail: 'Review AI forecasts in the Analytics view.',
+                    time: 'Today'
+                });
+            }
+            const missingLab = batches.filter(batch => (batch.labResults?.length ?? 0) === 0);
+            if (missingLab.length) {
+                notifications.push({
+                    type: 'action',
+                    message: `${missingLab.length} batch${missingLab.length === 1 ? '' : 'es'} awaiting lab results.`,
+                    detail: 'Log lab analyses to keep compliance reports ready.',
+                    time: 'Just now'
+                });
+            }
+        }
+
+        if (!notifications.length) {
+            notifications.push({
+                type: 'success',
+                message: 'All systems up to date.',
+                detail: 'No pending actions. Great work!',
+                time: 'Just now'
+            });
+        }
+
+        return notifications.slice(0, 4);
+    }
+
+    updateNotificationBadge() {
+        const badge = document.querySelector('.btn-notifications .badge');
+        if (!badge) {
+            return;
+        }
+        const count = this.notifications.length;
+        badge.textContent = count > 99 ? '99+' : String(count);
+        badge.hidden = count === 0;
+    }
+
+    renderNotificationList() {
+        const list = document.getElementById('notificationList');
+        if (!list) {
+            return;
+        }
+        list.innerHTML = '';
+        this.notifications.forEach(notification => {
+            const item = document.createElement('li');
+            item.className = `notification-item ${notification.type ?? 'info'}`;
+            item.innerHTML = `
+                <p class="notification-message">${notification.message}</p>
+                ${notification.detail ? `<p class="notification-detail">${notification.detail}</p>` : ''}
+                <span class="notification-time">${notification.time ?? ''}</span>
+            `;
+            list.appendChild(item);
+        });
+    }
+
+    updateNotifications() {
+        this.notifications = this.buildNotificationData();
+        this.updateNotificationBadge();
+        if (this.notificationsOpen) {
+            this.renderNotificationList();
+        }
+    }
+
+    toggleNotifications(force) {
+        const panel = document.getElementById('notificationPanel');
+        const button = document.querySelector('.btn-notifications');
+        if (!panel || !button) {
+            return;
+        }
+        const nextState = typeof force === 'boolean' ? force : !this.notificationsOpen;
+        this.notificationsOpen = nextState;
+        panel.classList.toggle('show', nextState);
+        panel.setAttribute('aria-hidden', nextState ? 'false' : 'true');
+        button.setAttribute('aria-expanded', String(nextState));
+        if (nextState) {
+            this.renderNotificationList();
+        }
+    }
+
+    toggleCellarViewMode() {
+        this.cellar3DEnabled = !this.cellar3DEnabled;
+        this.renderCellarMap();
     }
 
     renderTemperatureChart() {
@@ -403,5 +1110,12 @@ function closeModal() {
 }
 
 function toggleCellar3D() {
-    alert('3D view coming soon!');
+    enhancedApp.toggleCellarViewMode();
+}
+
+function toggleNotifications(event) {
+    if (event) {
+        event.stopPropagation();
+    }
+    enhancedApp.toggleNotifications();
 }

--- a/enhanced-dashboard.html
+++ b/enhanced-dashboard.html
@@ -15,124 +15,213 @@
                 <h2>VineTrack Pro</h2>
             </div>
             <ul class="nav-menu">
-                <li class="nav-item active"><span>Dashboard</span></li>
-                <li class="nav-item"><span>Tanks</span></li>
-                <li class="nav-item"><span>Batches</span></li>
-                <li class="nav-item"><span>Laboratory</span></li>
-                <li class="nav-item"><span>Production</span></li>
-                <li class="nav-item"><span>Analytics</span></li>
-                <li class="nav-item"><span>Settings</span></li>
+                <li><button type="button" class="nav-item active" data-view="dashboard" aria-controls="view-dashboard" aria-current="page">Dashboard</button></li>
+                <li><button type="button" class="nav-item" data-view="tanks" aria-controls="view-tanks">Tanks</button></li>
+                <li><button type="button" class="nav-item" data-view="batches" aria-controls="view-batches">Batches</button></li>
+                <li><button type="button" class="nav-item" data-view="laboratory" aria-controls="view-laboratory">Laboratory</button></li>
+                <li><button type="button" class="nav-item" data-view="production" aria-controls="view-production">Production</button></li>
+                <li><button type="button" class="nav-item" data-view="analytics" aria-controls="view-analytics">Analytics</button></li>
+                <li><button type="button" class="nav-item" data-view="settings" aria-controls="view-settings">Settings</button></li>
             </ul>
         </nav>
 
         <main class="main-content">
             <header class="dashboard-header glass-card">
                 <div class="search-bar">
-                    <input type="text" placeholder="Search batches, tanks, or wines...">
-                    <button class="btn-search">🔍</button>
+                    <input type="text" placeholder="Search batches, tanks, or wines..." aria-label="Search batches, tanks, or wines">
+                    <button class="btn-search" type="button" aria-label="Search">🔍</button>
                 </div>
                 <div class="quick-actions">
-                    <button class="btn-scan" onclick="openBarcodeScanner()">📷 Scan</button>
-                    <button class="btn-add-reading" onclick="quickAddReading()">➕ Quick Add</button>
-                    <button class="btn-notifications">🔔 <span class="badge">3</span></button>
+                    <button class="btn-scan" type="button" onclick="openBarcodeScanner()">📷 Scan</button>
+                    <button class="btn-add-reading" type="button" onclick="quickAddReading()">➕ Quick Add</button>
+                    <button class="btn-notifications" type="button" onclick="toggleNotifications(event)" aria-haspopup="true" aria-expanded="false">
+                        🔔 <span class="badge" aria-live="polite">0</span>
+                    </button>
                 </div>
                 <div class="user-profile">
                     <img src="user-avatar.jpg" alt="User" width="48" height="48">
                     <span>Winemaker</span>
                 </div>
+                <div id="notificationPanel" class="notification-panel glass-card" aria-hidden="true">
+                    <div class="panel-header">
+                        <h3>Notifications</h3>
+                        <button type="button" class="panel-close" onclick="toggleNotifications(event)" aria-label="Close notifications">✕</button>
+                    </div>
+                    <ul id="notificationList" class="notification-list"></ul>
+                </div>
             </header>
 
-            <div class="kpi-grid">
-                <div class="kpi-card glass-card">
-                    <div class="kpi-icon">🍇</div>
-                    <div class="kpi-content">
-                        <h3>Active Fermentations</h3>
-                        <p class="kpi-value" id="kpiFermentations">0</p>
-                        <span class="kpi-trend positive" id="kpiFermentationTrend"></span>
+            <div class="view-container">
+                <section class="view-panel active" data-view="dashboard" id="view-dashboard" aria-label="Dashboard overview" aria-hidden="false">
+                    <div class="kpi-grid">
+                        <div class="kpi-card glass-card">
+                            <div class="kpi-icon">🍇</div>
+                            <div class="kpi-content">
+                                <h3>Active Fermentations</h3>
+                                <p class="kpi-value" id="kpiFermentations">0</p>
+                                <span class="kpi-trend positive" id="kpiFermentationTrend"></span>
+                            </div>
+                        </div>
+                        <div class="kpi-card glass-card">
+                            <div class="kpi-icon">🏺</div>
+                            <div class="kpi-content">
+                                <h3>Total Volume</h3>
+                                <p class="kpi-value" id="kpiVolume">0 L</p>
+                                <span class="kpi-trend" id="kpiCapacity"></span>
+                            </div>
+                        </div>
+                        <div class="kpi-card glass-card">
+                            <div class="kpi-icon">⚗️</div>
+                            <div class="kpi-content">
+                                <h3>Lab Samples Today</h3>
+                                <p class="kpi-value" id="kpiLabSamples">0</p>
+                                <span class="kpi-trend" id="kpiLabPending"></span>
+                            </div>
+                        </div>
+                        <div class="kpi-card glass-card">
+                            <div class="kpi-icon">📊</div>
+                            <div class="kpi-content">
+                                <h3>Quality Score</h3>
+                                <p class="kpi-value" id="kpiQuality">0</p>
+                                <span class="kpi-trend positive" id="kpiQualityTrend"></span>
+                            </div>
+                        </div>
                     </div>
-                </div>
-                <div class="kpi-card glass-card">
-                    <div class="kpi-icon">🏺</div>
-                    <div class="kpi-content">
-                        <h3>Total Volume</h3>
-                        <p class="kpi-value" id="kpiVolume">0 L</p>
-                        <span class="kpi-trend" id="kpiCapacity"></span>
+
+                    <section class="cellar-map glass-card">
+                        <h2>Cellar Overview</h2>
+                        <div class="cellar-controls">
+                            <label for="cellarView" class="visually-hidden">Cellar view mode</label>
+                            <select id="cellarView">
+                                <option value="status">By Status</option>
+                                <option value="variety">By Variety</option>
+                                <option value="temperature">By Temperature</option>
+                            </select>
+                            <button type="button" data-action="toggle-3d" onclick="toggleCellar3D()" aria-pressed="false">3D View</button>
+                        </div>
+                        <div id="cellarVisualization"></div>
+                    </section>
+
+                    <section class="monitoring-grid">
+                        <div class="monitor-card glass-card">
+                            <h3>Temperature Monitoring</h3>
+                            <canvas id="tempMonitorChart" aria-label="Tank temperature trends" role="img"></canvas>
+                        </div>
+                        <div class="monitor-card glass-card">
+                            <h3>Fermentation Progress</h3>
+                            <div id="fermentationProgress"></div>
+                        </div>
+                        <div class="monitor-card glass-card">
+                            <h3>Recent Activities</h3>
+                            <div class="activity-feed" id="activityFeed"></div>
+                        </div>
+                    </section>
+
+                    <section class="batch-timeline-section glass-card">
+                        <h2>Production Timeline</h2>
+                        <div class="batch-timeline" id="productionTimeline">
+                            <div class="timeline-line"></div>
+                        </div>
+                    </section>
+                </section>
+
+                <section class="view-panel" data-view="tanks" id="view-tanks" aria-label="Tank overview" aria-hidden="true">
+                    <div class="panel-header">
+                        <h2>Tank Overview</h2>
+                        <p>Monitor cellar capacity, assignments, and the freshness of your readings.</p>
                     </div>
-                </div>
-                <div class="kpi-card glass-card">
-                    <div class="kpi-icon">⚗️</div>
-                    <div class="kpi-content">
-                        <h3>Lab Samples Today</h3>
-                        <p class="kpi-value" id="kpiLabSamples">0</p>
-                        <span class="kpi-trend" id="kpiLabPending"></span>
+                    <div id="tankOverviewList" class="list-grid"></div>
+                    <div id="tanksEmptyState" class="empty-state glass-card" hidden>
+                        <h3>No tanks configured yet</h3>
+                        <p>Import your cellar layout or use Quick Add to start tracking fermentation vessels.</p>
                     </div>
-                </div>
-                <div class="kpi-card glass-card">
-                    <div class="kpi-icon">📊</div>
-                    <div class="kpi-content">
-                        <h3>Quality Score</h3>
-                        <p class="kpi-value" id="kpiQuality">0</p>
-                        <span class="kpi-trend positive" id="kpiQualityTrend"></span>
+                </section>
+
+                <section class="view-panel" data-view="batches" id="view-batches" aria-label="Batch management" aria-hidden="true">
+                    <div class="panel-header">
+                        <h2>Batch Management</h2>
+                        <p>Track varietals, volumes, and statuses across your cellar.</p>
                     </div>
-                </div>
+                    <div id="batchOverviewList" class="list-grid"></div>
+                    <div id="batchesEmptyState" class="empty-state glass-card" hidden>
+                        <h3>No batches recorded</h3>
+                        <p>Create a batch from a tank to begin capturing fermentation history.</p>
+                    </div>
+                </section>
+
+                <section class="view-panel" data-view="laboratory" id="view-laboratory" aria-label="Laboratory results" aria-hidden="true">
+                    <div class="panel-header">
+                        <h2>Laboratory Results</h2>
+                        <p>Review the latest chemistry and quality metrics from your lab team.</p>
+                    </div>
+                    <div id="labResultsList" class="list-grid"></div>
+                    <div id="labEmptyState" class="empty-state glass-card" hidden>
+                        <h3>No lab results yet</h3>
+                        <p>When you add analyses to a batch, the most recent measurements will appear here.</p>
+                    </div>
+                </section>
+
+                <section class="view-panel" data-view="production" id="view-production" aria-label="Production schedule" aria-hidden="true">
+                    <div class="panel-header">
+                        <h2>Production Planning</h2>
+                        <p>Coordinate harvest, fermentation, aging, and bottling activities.</p>
+                    </div>
+                    <div id="productionSchedule" class="timeline-grid"></div>
+                    <div id="productionEmptyState" class="empty-state glass-card" hidden>
+                        <h3>No production plan available</h3>
+                        <p>Set your vintage to generate a timeline with resource utilization insights.</p>
+                    </div>
+                </section>
+
+                <section class="view-panel" data-view="analytics" id="view-analytics" aria-label="Analytics" aria-hidden="true">
+                    <div class="panel-header">
+                        <h2>AI Analytics</h2>
+                        <p>Forecast fermentation completion dates and identify potential risks.</p>
+                    </div>
+                    <div id="analyticsSummary" class="list-grid analytics-grid"></div>
+                    <div id="analyticsEmptyState" class="empty-state glass-card" hidden>
+                        <h3>Analytics will appear here</h3>
+                        <p>Add readings to your tanks to unlock AI-powered fermentation forecasts.</p>
+                    </div>
+                </section>
+
+                <section class="view-panel" data-view="settings" id="view-settings" aria-label="System settings" aria-hidden="true">
+                    <div class="panel-header">
+                        <h2>System Settings</h2>
+                        <p>Review connectivity, integrations, and AI readiness for your winery.</p>
+                    </div>
+                    <div id="settingsPanel" class="settings-grid"></div>
+                </section>
             </div>
-
-            <section class="cellar-map glass-card">
-                <h2>Cellar Overview</h2>
-                <div class="cellar-controls">
-                    <select id="cellarView">
-                        <option value="status">By Status</option>
-                        <option value="variety">By Variety</option>
-                        <option value="temperature">By Temperature</option>
-                    </select>
-                    <button onclick="toggleCellar3D()">3D View</button>
-                </div>
-                <div id="cellarVisualization"></div>
-            </section>
-
-            <section class="monitoring-grid">
-                <div class="monitor-card glass-card">
-                    <h3>Temperature Monitoring</h3>
-                    <canvas id="tempMonitorChart"></canvas>
-                </div>
-                <div class="monitor-card glass-card">
-                    <h3>Fermentation Progress</h3>
-                    <div id="fermentationProgress"></div>
-                </div>
-                <div class="monitor-card glass-card">
-                    <h3>Recent Activities</h3>
-                    <div class="activity-feed" id="activityFeed"></div>
-                </div>
-            </section>
-
-            <section class="batch-timeline-section glass-card">
-                <h2>Production Timeline</h2>
-                <div class="batch-timeline" id="productionTimeline">
-                    <div class="timeline-line"></div>
-                </div>
-            </section>
         </main>
     </div>
 
-    <div id="quickAddModal" class="modal">
+    <div id="quickAddModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="quickAddTitle">
         <div class="modal-content glass-card">
-            <h2>Quick Reading</h2>
+            <h2 id="quickAddTitle">Quick Reading</h2>
             <form id="quickReadingForm">
+                <label for="quickTank" class="visually-hidden">Tank</label>
                 <select id="quickTank" required></select>
+                <label for="quickTemp" class="visually-hidden">Temperature</label>
                 <input type="number" id="quickTemp" placeholder="Temperature (°C)" step="0.1">
+                <label for="quickSugar" class="visually-hidden">Sugar</label>
                 <input type="number" id="quickSugar" placeholder="Sugar (Baumé)" step="0.1">
+                <label for="quickPH" class="visually-hidden">pH</label>
                 <input type="number" id="quickPH" placeholder="pH" step="0.01">
-                <button type="submit">Save</button>
-                <button type="button" onclick="closeModal()">Cancel</button>
+                <div class="modal-actions">
+                    <button type="submit">Save</button>
+                    <button type="button" onclick="closeModal()">Cancel</button>
+                </div>
             </form>
         </div>
     </div>
 
-    <div id="scannerModal" class="modal">
+    <div id="scannerModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="scannerTitle">
         <div class="modal-content">
+            <h2 id="scannerTitle" class="visually-hidden">Barcode scanner</h2>
             <video id="scannerVideo" autoplay muted playsinline></video>
             <div id="scanResult"></div>
-            <button onclick="closeScannerModal()">Close</button>
+            <button type="button" onclick="closeScannerModal()">Close</button>
         </div>
     </div>
 

--- a/enhanced-styles.css
+++ b/enhanced-styles.css
@@ -48,18 +48,33 @@
     gap: 1rem;
 }
 
-.nav-item {
+.nav-menu li {
+    list-style: none;
+}
+
+.nav-menu .nav-item {
     display: flex;
     align-items: center;
     gap: 0.75rem;
     padding: 0.75rem 1rem;
     border-radius: 12px;
     cursor: pointer;
-    transition: background 0.3s;
+    transition: background 0.3s, transform 0.2s;
+    background: transparent;
+    border: none;
+    color: inherit;
+    font: inherit;
+    width: 100%;
+    text-align: left;
 }
 
-.nav-item.active,
-.nav-item:hover {
+.nav-menu .nav-item:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.6);
+    outline-offset: 2px;
+}
+
+.nav-menu .nav-item.active,
+.nav-menu .nav-item:hover {
     background: rgba(255, 255, 255, 0.2);
 }
 
@@ -75,6 +90,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
+    position: relative;
 }
 
 .search-bar {
@@ -258,6 +274,418 @@
 .activity-feed {
     max-height: 250px;
     overflow-y: auto;
+}
+
+.quick-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.quick-actions button {
+    background: rgba(255, 255, 255, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    color: inherit;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    font-weight: 600;
+    transition: transform 0.2s ease, background 0.3s ease;
+}
+
+.quick-actions button:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.3);
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.5rem;
+    padding: 0 0.4rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.25);
+    font-size: 0.75rem;
+    margin-left: 0.4rem;
+    font-weight: 600;
+}
+
+.btn-notifications[aria-expanded="true"] .badge {
+    background: rgba(255, 255, 255, 0.5);
+}
+
+.view-container {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    position: relative;
+}
+
+.view-panel {
+    display: none;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.view-panel.active {
+    display: flex;
+}
+
+.panel-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.panel-header h2 {
+    font-size: 1.8rem;
+    font-weight: 600;
+}
+
+.panel-header p {
+    color: rgba(255, 255, 255, 0.85);
+    max-width: 620px;
+}
+
+.list-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.analytics-grid {
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+.timeline-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.settings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.empty-state {
+    text-align: center;
+    border: 1px dashed rgba(255, 255, 255, 0.35);
+    padding: 2rem;
+}
+
+.empty-state h3 {
+    font-size: 1.4rem;
+    margin-bottom: 0.5rem;
+}
+
+.empty-state p {
+    color: rgba(255, 255, 255, 0.75);
+    margin: 0;
+}
+
+.tank-overview-card header,
+.batch-overview-card header,
+.analytics-card header,
+.settings-card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.metric-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.75rem;
+    margin: 1rem 0;
+}
+
+.metric-list div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.metric-list dt {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.7;
+}
+
+.metric-list dd {
+    margin: 0;
+    font-weight: 600;
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.18);
+}
+
+.status-pill.status-active {
+    background: rgba(46, 125, 50, 0.35);
+}
+
+.status-pill.status-success {
+    background: rgba(120, 200, 120, 0.35);
+}
+
+.status-pill.status-idle {
+    background: rgba(255, 255, 255, 0.18);
+}
+
+.status-pill.status-warning {
+    background: rgba(255, 193, 7, 0.35);
+}
+
+.status-pill.status-planned {
+    background: rgba(114, 47, 55, 0.35);
+}
+
+.progress {
+    width: 100%;
+    height: 8px;
+    background: rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+    overflow: hidden;
+    margin-top: 0.75rem;
+}
+
+.progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, var(--secondary), rgba(255, 255, 255, 0.7));
+}
+
+.progress-label {
+    font-size: 0.8rem;
+    opacity: 0.8;
+    margin-top: 0.25rem;
+}
+
+.notification-panel {
+    position: absolute;
+    top: calc(100% + 1rem);
+    right: 0;
+    width: min(320px, 80vw);
+    display: none;
+    z-index: 20;
+    padding: 1.25rem;
+}
+
+.notification-panel.show {
+    display: block;
+}
+
+.notification-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.notification-item {
+    padding: 0.75rem 0.9rem;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.notification-item.info {
+    border-left: 3px solid rgba(120, 144, 255, 0.6);
+}
+
+.notification-item.warning {
+    border-left: 3px solid rgba(255, 202, 40, 0.7);
+}
+
+.notification-item.success {
+    border-left: 3px solid rgba(46, 125, 50, 0.6);
+}
+
+.notification-item.action {
+    border-left: 3px solid rgba(255, 255, 255, 0.6);
+}
+
+.notification-message {
+    font-weight: 600;
+}
+
+.notification-detail {
+    font-size: 0.85rem;
+    opacity: 0.8;
+}
+
+.notification-time {
+    font-size: 0.75rem;
+    opacity: 0.6;
+}
+
+.panel-close {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+.settings-card ul,
+.production-card ul,
+.suggestions-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.production-card footer,
+.settings-card footer {
+    margin-top: 1rem;
+    font-size: 0.8rem;
+    opacity: 0.7;
+}
+
+.modal-actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+}
+
+.modal-actions button {
+    flex: 1;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    border: none;
+    font-weight: 600;
+    cursor: pointer;
+    background: rgba(255, 255, 255, 0.2);
+    color: inherit;
+}
+
+.modal-actions button[type="submit"] {
+    background: linear-gradient(120deg, var(--secondary), rgba(255, 255, 255, 0.6));
+    color: var(--dark);
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
+.cellar-controls select,
+.cellar-controls button {
+    background: rgba(255, 255, 255, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 999px;
+    padding: 0.45rem 1rem;
+    color: inherit;
+}
+
+.cellar-controls button[aria-pressed="true"] {
+    background: rgba(255, 255, 255, 0.35);
+}
+
+.cellar-3d {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem;
+    perspective: 1100px;
+}
+
+.cellar-3d__tank {
+    position: relative;
+    padding: 1.5rem;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.12);
+    min-height: 200px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    overflow: hidden;
+}
+
+.cellar-3d__tank::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.15));
+    transform: rotateX(55deg);
+    transform-origin: top;
+    opacity: 0.35;
+    pointer-events: none;
+}
+
+.cellar-3d__tank h3 {
+    margin-bottom: 0.5rem;
+}
+
+.cellar-3d__meta {
+    font-size: 0.85rem;
+    opacity: 0.8;
+}
+
+.cellar-3d__level {
+    position: relative;
+    height: 120px;
+    border-radius: 14px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    overflow: hidden;
+}
+
+.cellar-3d__level-fill {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: linear-gradient(180deg, rgba(114, 47, 55, 0.8), rgba(114, 47, 55, 0.4));
+}
+
+.production-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.analytics-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.analytics-card footer {
+    font-size: 0.85rem;
+    opacity: 0.75;
+}
+
+.settings-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.settings-card .status-pill {
+    align-self: flex-start;
 }
 
 .modal {


### PR DESCRIPTION
## Summary
- convert the sidebar navigation into real buttons, add a notification drawer, and reorganize the dashboard layout into switchable panels
- style the new views, quick actions, empty states, notification drawer, and 3D cellar representation for consistency across the app
- wire up navigation switching, tank/batch/lab/production/analytics renderers, cellar 3D toggle, and notification badge logic to provide interactive behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3a8651e10832dad4f5a1e0a55abea