### PR TITLE
Add harvest intake workflow and UI integration

### DIFF
--- a/assets/css/landing.css
+++ b/assets/css/landing.css
@@ -1,0 +1,804 @@
+:root {
+    --primary: #722f37;
+    --secondary: #b8860b;
+    --accent: #2e7d32;
+    --dark: #1a1a1a;
+    --light: #f7f4ef;
+    --gray-100: #f8f9fa;
+    --gray-200: #e9ecef;
+    --gray-300: #dee2e6;
+    --gray-400: #ced4da;
+    --gray-500: #adb5bd;
+    --gray-600: #6c757d;
+    --gray-700: #495057;
+    --gray-800: #343a40;
+    --gray-900: #212529;
+    --font-primary: 'Montserrat', sans-serif;
+    --font-secondary: 'Playfair Display', serif;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: var(--font-primary);
+    line-height: 1.6;
+    color: var(--gray-800);
+    background-color: var(--light);
+}
+
+a {
+    text-decoration: none;
+    color: inherit;
+}
+
+.hero-header {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+    backdrop-filter: blur(8px);
+}
+
+.header-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 18px 24px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.logo-container {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.logo {
+    width: 40px;
+    height: 40px;
+}
+
+.logo-title {
+    font-weight: 600;
+    font-size: 1.4rem;
+    color: var(--primary);
+}
+
+.main-nav {
+    display: flex;
+    align-items: center;
+    gap: 22px;
+}
+
+.nav-link {
+    color: var(--gray-700);
+    font-weight: 500;
+    transition: color 0.3s ease, transform 0.3s ease;
+}
+
+.nav-link:hover,
+.nav-link.active {
+    color: var(--primary);
+    transform: translateY(-1px);
+}
+
+.btn-primary,
+.btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 10px;
+    font-weight: 600;
+    padding: 12px 24px;
+    border: 2px solid transparent;
+    transition: all 0.3s ease;
+    cursor: pointer;
+}
+
+.btn-primary {
+    background: var(--primary);
+    color: #fff;
+}
+
+.btn-primary:hover {
+    background: #5a252b;
+    box-shadow: 0 10px 24px rgba(114, 47, 55, 0.25);
+    transform: translateY(-2px);
+}
+
+.btn-secondary {
+    background: transparent;
+    color: var(--primary);
+    border-color: var(--primary);
+}
+
+.btn-secondary:hover {
+    background: var(--primary);
+    color: #fff;
+}
+
+.btn-large {
+    padding: 16px 32px;
+    font-size: 1.05rem;
+}
+
+.hero-section {
+    padding: 160px 24px 100px;
+    background: linear-gradient(135deg, #f8f9fa 0%, #ece7de 100%);
+}
+
+.hero-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.hero-content h1 {
+    font-family: var(--font-secondary);
+    font-size: clamp(2.5rem, 4vw, 3.5rem);
+    color: var(--primary);
+    margin-bottom: 20px;
+}
+
+.hero-subtitle {
+    max-width: 720px;
+    margin: 0 auto;
+    color: var(--gray-700);
+    font-size: 1.2rem;
+}
+
+.hero-cta {
+    margin-top: 32px;
+    display: flex;
+    justify-content: center;
+    gap: 18px;
+    flex-wrap: wrap;
+}
+
+.hero-visual {
+    margin-top: 60px;
+    display: flex;
+    justify-content: center;
+}
+
+.dashboard-preview {
+    width: min(100%, 820px);
+    border-radius: 24px;
+    padding: 32px;
+    background: #fff;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.12);
+    position: relative;
+    overflow: hidden;
+}
+
+.dashboard-preview::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(114, 47, 55, 0.05), rgba(46, 125, 50, 0.08));
+    pointer-events: none;
+}
+
+.dashboard-header {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-bottom: 24px;
+}
+
+.status-chip {
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.status-chip.success {
+    background: rgba(46, 125, 50, 0.12);
+    color: var(--accent);
+}
+
+.status-chip.warning {
+    background: rgba(184, 134, 11, 0.15);
+    color: var(--secondary);
+}
+
+.dashboard-body {
+    display: grid;
+    gap: 18px;
+}
+
+.metric-card {
+    background: var(--gray-100);
+    border-radius: 16px;
+    padding: 18px;
+    text-align: left;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.metric-label {
+    font-size: 0.85rem;
+    color: var(--gray-600);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.metric-value {
+    font-size: 1.6rem;
+    font-weight: 600;
+    color: var(--primary);
+}
+
+.sparkline {
+    height: 140px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, rgba(114, 47, 55, 0.08), rgba(46, 125, 50, 0.12));
+    position: relative;
+    overflow: hidden;
+}
+
+.sparkline::before,
+.sparkline::after {
+    content: '';
+    position: absolute;
+    inset: 15% 5%;
+    border-radius: 12px;
+    border: 2px dashed rgba(114, 47, 55, 0.25);
+}
+
+.sparkline::after {
+    inset: 35% 10% 20% 25%;
+    border-color: rgba(46, 125, 50, 0.3);
+}
+
+.section-header {
+    text-align: center;
+    max-width: 720px;
+    margin: 0 auto 48px;
+}
+
+.section-header h2 {
+    font-family: var(--font-secondary);
+    font-size: clamp(2rem, 3vw, 2.6rem);
+    color: var(--primary);
+    margin-bottom: 14px;
+}
+
+.section-header p {
+    color: var(--gray-600);
+    font-size: 1.05rem;
+}
+
+.features-section,
+.how-it-works,
+.testimonials-section,
+.pricing-section,
+.demo-section {
+    padding: 100px 24px;
+}
+
+.features-grid {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 28px;
+}
+
+.feature-card {
+    background: #fff;
+    border-radius: 20px;
+    padding: 28px;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.feature-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 24px 50px rgba(0, 0, 0, 0.12);
+}
+
+.feature-icon {
+    font-size: 2.4rem;
+    margin-bottom: 18px;
+}
+
+.feature-card h3 {
+    font-size: 1.4rem;
+    margin-bottom: 12px;
+    color: var(--primary);
+}
+
+.feature-card p {
+    color: var(--gray-600);
+}
+
+.feature-list {
+    margin-top: 16px;
+    list-style: none;
+}
+
+.feature-list li {
+    padding-left: 22px;
+    position: relative;
+    margin-bottom: 10px;
+    color: var(--gray-700);
+}
+
+.feature-list li::before {
+    content: '•';
+    position: absolute;
+    left: 0;
+    top: 0;
+    color: var(--primary);
+}
+
+.how-it-works {
+    background: #fff;
+}
+
+.process-steps {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 24px;
+}
+
+.step {
+    background: var(--gray-100);
+    border-radius: 18px;
+    padding: 28px;
+    text-align: center;
+    border: 1px solid rgba(114, 47, 55, 0.08);
+}
+
+.step-number {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--primary);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    margin-bottom: 14px;
+}
+
+.compliance-section {
+    background: linear-gradient(135deg, var(--primary) 0%, #5a252b 100%);
+    color: #fff;
+    padding: 100px 24px;
+}
+
+.compliance-content {
+    max-width: 1180px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 36px;
+    align-items: center;
+}
+
+.compliance-text p {
+    margin-top: 12px;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.compliance-list {
+    list-style: none;
+    margin-top: 24px;
+}
+
+.compliance-list li {
+    position: relative;
+    padding-left: 28px;
+    margin-bottom: 14px;
+}
+
+.compliance-list li::before {
+    content: '✓';
+    position: absolute;
+    left: 0;
+    color: var(--secondary);
+    font-weight: 700;
+}
+
+.compliance-visual {
+    position: relative;
+    aspect-ratio: 1 / 1;
+    max-width: 320px;
+    margin: 0 auto;
+}
+
+.compliance-ring {
+    position: absolute;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.35);
+    animation: pulse 6s infinite;
+}
+
+.ring-one {
+    inset: 0;
+}
+
+.ring-two {
+    inset: 12%;
+    animation-delay: 1.2s;
+}
+
+.ring-three {
+    inset: 24%;
+    animation-delay: 2.4s;
+}
+
+.compliance-center {
+    position: absolute;
+    inset: 36%;
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 50%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-weight: 700;
+}
+
+.compliance-center span {
+    font-size: 1.8rem;
+}
+
+.compliance-center small {
+    margin-top: 4px;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+}
+
+@keyframes pulse {
+    0% { opacity: 0.2; }
+    50% { opacity: 1; }
+    100% { opacity: 0.2; }
+}
+
+.testimonials-grid {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 28px;
+}
+
+.testimonial-card {
+    background: #fff;
+    border-radius: 20px;
+    padding: 28px;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
+}
+
+.testimonial-content {
+    font-style: italic;
+    color: var(--gray-700);
+    margin-bottom: 22px;
+}
+
+.testimonial-author {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.author-avatar {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--primary), var(--secondary));
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+}
+
+.author-avatar span {
+    transform: translateY(1px);
+}
+
+.pricing-section {
+    background: var(--gray-100);
+}
+
+.pricing-cards {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 28px;
+}
+
+.pricing-card {
+    position: relative;
+    background: #fff;
+    border-radius: 22px;
+    padding: 36px 28px;
+    text-align: center;
+    box-shadow: 0 18px 44px rgba(0, 0, 0, 0.08);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.pricing-card:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 26px 60px rgba(0, 0, 0, 0.12);
+}
+
+.featured {
+    border: 2px solid var(--primary);
+    transform: scale(1.02);
+}
+
+.featured-label {
+    position: absolute;
+    top: 16px;
+    right: 22px;
+    background: var(--primary);
+    color: #fff;
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+}
+
+.price {
+    font-size: 2.8rem;
+    font-weight: 700;
+    color: var(--primary);
+    margin: 12px 0;
+}
+
+.price span {
+    font-size: 1rem;
+    color: var(--gray-500);
+    margin-left: 4px;
+}
+
+.price-subtitle {
+    color: var(--gray-600);
+    margin-bottom: 20px;
+}
+
+.pricing-features {
+    list-style: none;
+    margin-bottom: 28px;
+}
+
+.pricing-features li {
+    padding: 10px 0;
+    border-bottom: 1px solid var(--gray-200);
+    color: var(--gray-700);
+}
+
+.pricing-features li:last-child {
+    border-bottom: none;
+}
+
+.demo-section {
+    background: #fff;
+}
+
+.demo-preview {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 24px;
+}
+
+.demo-card {
+    background: var(--gray-100);
+    border-radius: 18px;
+    padding: 24px;
+    border: 1px solid rgba(114, 47, 55, 0.08);
+    color: var(--gray-700);
+}
+
+.contact-section {
+    padding: 100px 24px;
+    background: linear-gradient(135deg, var(--primary) 0%, #5a252b 100%);
+    color: #fff;
+}
+
+.contact-container {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 40px;
+    align-items: center;
+}
+
+.contact-content h2 {
+    font-family: var(--font-secondary);
+    font-size: clamp(2.2rem, 3vw, 2.6rem);
+    margin-bottom: 16px;
+}
+
+.contact-content p {
+    font-size: 1.05rem;
+    margin-bottom: 22px;
+}
+
+.small-text {
+    font-size: 0.9rem;
+    opacity: 0.8;
+}
+
+.contact-form {
+    background: #fff;
+    color: var(--gray-800);
+    border-radius: 20px;
+    padding: 32px;
+    box-shadow: 0 24px 48px rgba(0, 0, 0, 0.15);
+}
+
+.form-group {
+    margin-bottom: 18px;
+}
+
+label {
+    display: block;
+    margin-bottom: 6px;
+    font-weight: 600;
+    color: var(--gray-700);
+}
+
+input,
+select,
+textarea {
+    width: 100%;
+    padding: 12px 14px;
+    border-radius: 10px;
+    border: 1px solid var(--gray-300);
+    font-size: 1rem;
+    font-family: inherit;
+}
+
+.site-footer {
+    background: var(--dark);
+    color: #fff;
+    padding: 70px 24px 40px;
+}
+
+.footer-container {
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.footer-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+    margin-bottom: 40px;
+    flex-wrap: wrap;
+}
+
+.footer-logo {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+
+.footer-logo h3 {
+    font-size: 1.5rem;
+    color: #fff;
+}
+
+.footer-tagline {
+    color: rgba(255, 255, 255, 0.7);
+    max-width: 420px;
+}
+
+.footer-columns {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 28px;
+    margin-bottom: 36px;
+}
+
+.footer-column h4 {
+    color: var(--secondary);
+    margin-bottom: 12px;
+}
+
+.footer-links {
+    list-style: none;
+}
+
+.footer-links li {
+    margin-bottom: 10px;
+}
+
+.footer-links a {
+    color: rgba(255, 255, 255, 0.75);
+    transition: color 0.3s ease;
+}
+
+.footer-links a:hover {
+    color: #fff;
+}
+
+.footer-bottom {
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    padding-top: 24px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.footer-social {
+    display: flex;
+    gap: 16px;
+}
+
+.footer-social a {
+    color: rgba(255, 255, 255, 0.7);
+    font-weight: 600;
+}
+
+.footer-social a:hover {
+    color: #fff;
+}
+
+@media (max-width: 960px) {
+    .main-nav {
+        display: none;
+    }
+
+    .hero-section {
+        padding-top: 140px;
+    }
+}
+
+@media (max-width: 680px) {
+    .hero-content h1 {
+        font-size: 2.1rem;
+    }
+
+    .hero-subtitle {
+        font-size: 1.05rem;
+    }
+
+    .dashboard-preview {
+        padding: 24px;
+    }
+
+    .dashboard-body {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+}
+
+@media (max-width: 540px) {
+    .btn-large {
+        width: 100%;
+    }
+
+    .footer-bottom {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .footer-social {
+        width: 100%;
+        justify-content: flex-start;
+    }
+}

--- a/assets/images/logo.svg
+++ b/assets/images/logo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-labelledby="title desc">
+  <title id="title">VineTrack Pro Logo</title>
+  <desc id="desc">Stylised grape cluster with initials VTP</desc>
+  <defs>
+    <linearGradient id="grapeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#722f37"/>
+      <stop offset="100%" stop-color="#b8860b"/>
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="18" fill="#f9f5f0"/>
+  <g transform="translate(20 18)">
+    <path d="M40 6c9 0 16 7 16 16s-7 16-16 16-16-7-16-16 7-16 16-16z" fill="url(#grapeGradient)" opacity="0.85"/>
+    <circle cx="20" cy="38" r="12" fill="#722f37" opacity="0.9"/>
+    <circle cx="60" cy="38" r="12" fill="#8a3b42" opacity="0.9"/>
+    <circle cx="40" cy="58" r="14" fill="#b8860b" opacity="0.95"/>
+    <path d="M40 0c8 6 12 12 12 18 0 6-4 12-12 18" fill="none" stroke="#2e7d32" stroke-width="4" stroke-linecap="round"/>
+    <text x="40" y="90" text-anchor="middle" font-family="'Montserrat', sans-serif" font-size="26" font-weight="700" fill="#2e2a27">VTP</text>
+  </g>
+</svg>

--- a/enhanced-app.js
+++ b/enhanced-app.js
@@ -8,6 +8,9 @@ class EnhancedDashboardApp {
         this.aiAnalytics = typeof AIAnalytics !== 'undefined' ? new AIAnalytics(this.batchManager) : null;
         this.apiIntegration = typeof APIIntegration !== 'undefined' ? new APIIntegration(this.batchManager) : null;
         this.pwaManager = typeof PWAManager !== 'undefined' ? new PWAManager() : null;
+        this.workflowManager = typeof HarvestWorkflowManager !== 'undefined'
+            ? new HarvestWorkflowManager(this.dataManager, this.batchManager)
+            : null;
         this.tanks = [];
         this.scannerStream = null;
         this.scanFrameRequest = null;
@@ -16,18 +19,32 @@ class EnhancedDashboardApp {
         this.scanResultElement = null;
         this.lastScanAttempt = 0;
         this.tempChart = null;
+        this.currentView = 'dashboard';
+        this.cellar3DEnabled = false;
+        this.notifications = [];
+        this.notificationsOpen = false;
+        this.handleDocumentClick = this.handleDocumentClick.bind(this);
+        this.handleEscape = this.handleEscape.bind(this);
     }
 
     async init() {
         await this.loadTanks();
         this.populateQuickAddSelector();
-        this.renderKPIs();
-        this.renderCellarMap();
-        this.renderTemperatureChart();
-        this.renderFermentationProgress();
-        this.renderActivityFeed();
-        this.renderTimeline();
+        this.bindNavigation();
         this.bindQuickAddForm();
+        this.bindHarvestWorkflowForm();
+        this.bindWorkflowActionHandlers();
+        this.bindNotificationPanel();
+        this.bindGlobalEvents();
+        this.updateNotifications();
+        this.renderTankOverview();
+        this.renderBatchOverview();
+        this.renderLabOverview();
+        this.renderProductionSchedule();
+        this.renderHarvestWorkflowBoard();
+        this.renderAnalyticsSummary();
+        this.renderSettingsPanel();
+        this.switchView(this.currentView);
     }
 
     async loadTanks() {
@@ -50,6 +67,51 @@ class EnhancedDashboardApp {
             option.textContent = `${tank.id} (${tank.capacity} L)`;
             select.appendChild(option);
         });
+    }
+
+    bindNavigation() {
+        const navItems = document.querySelectorAll('.nav-menu .nav-item[data-view]');
+        navItems.forEach(item => {
+            item.addEventListener('click', () => {
+                const targetView = item.dataset.view;
+                if (targetView) {
+                    this.switchView(targetView);
+                }
+            });
+        });
+    }
+
+    bindNotificationPanel() {
+        const panel = document.getElementById('notificationPanel');
+        if (panel) {
+            panel.addEventListener('click', (event) => event.stopPropagation());
+        }
+    }
+
+    bindGlobalEvents() {
+        document.addEventListener('click', this.handleDocumentClick);
+        document.addEventListener('keydown', this.handleEscape);
+    }
+
+    handleDocumentClick(event) {
+        if (!this.notificationsOpen) {
+            return;
+        }
+        const panel = document.getElementById('notificationPanel');
+        const button = document.querySelector('.btn-notifications');
+        if (!panel || !button) {
+            return;
+        }
+        if (panel.contains(event.target) || button.contains(event.target)) {
+            return;
+        }
+        this.toggleNotifications(false);
+    }
+
+    handleEscape(event) {
+        if (event.key === 'Escape' && this.notificationsOpen) {
+            this.toggleNotifications(false);
+        }
     }
 
     bindQuickAddForm() {
@@ -79,7 +141,793 @@ class EnhancedDashboardApp {
             this.renderTemperatureChart();
             this.renderFermentationProgress();
             this.renderActivityFeed();
+            this.renderTankOverview();
+            this.renderBatchOverview();
+            this.renderAnalyticsSummary();
+            this.updateNotifications();
         });
+    }
+
+    bindHarvestWorkflowForm() {
+        const form = document.getElementById('harvestIntakeForm');
+        if (!form || !this.workflowManager) {
+            return;
+        }
+
+        const setDefaultArrival = () => {
+            const arrivalInput = document.getElementById('intakeArrival');
+            if (!arrivalInput) {
+                return;
+            }
+            const formatted = this.formatInputDate(new Date(), true);
+            arrivalInput.value = formatted;
+        };
+
+        setDefaultArrival();
+
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+            const data = new FormData(form);
+            const payload = {
+                arrivalTime: data.get('arrivalTime') || null,
+                vineyard: (data.get('vineyard') || '').trim(),
+                block: (data.get('block') || '').trim(),
+                variety: (data.get('variety') || '').trim(),
+                vehicleType: data.get('vehicleType') || 'tractor-trailer',
+                crateCount: data.get('crateCount'),
+                crateWeight: data.get('crateWeight'),
+                notes: (data.get('notes') || '').trim(),
+                route: data.get('route') || 'press'
+            };
+            this.workflowManager.createTransport(payload);
+            form.reset();
+            setDefaultArrival();
+            this.handleWorkflowChange({ refreshBatches: false });
+        });
+    }
+
+    bindWorkflowActionHandlers() {
+        const list = document.getElementById('harvestWorkflowList');
+        if (!list || !this.workflowManager) {
+            return;
+        }
+
+        list.addEventListener('submit', (event) => {
+            const form = event.target instanceof HTMLFormElement
+                ? event.target
+                : event.target.closest('form[data-workflow-id]');
+            if (!form) {
+                return;
+            }
+            event.preventDefault();
+            const workflowId = form.dataset.workflowId;
+            const action = form.dataset.action;
+            if (!workflowId || !action) {
+                return;
+            }
+            this.handleWorkflowAction(action, workflowId, new FormData(form));
+        });
+    }
+
+    handleWorkflowAction(action, workflowId, formData) {
+        if (!this.workflowManager) {
+            return;
+        }
+        const values = Object.fromEntries(formData.entries());
+        const trimmed = (input) => (input ?? '').toString().trim();
+        switch (action) {
+            case 'destemming':
+                this.workflowManager.recordDestemming(workflowId, {
+                    timestamp: values.timestamp || null,
+                    route: values.route || 'press',
+                    tankId: trimmed(values.tankId) || null,
+                    estimatedVolume: values.estimatedVolume,
+                    notes: trimmed(values.notes)
+                });
+                this.handleWorkflowChange({ refreshBatches: false });
+                break;
+            case 'pressing':
+                this.workflowManager.recordPressing(workflowId, {
+                    timestamp: values.timestamp || null,
+                    pressId: trimmed(values.pressId),
+                    mustVolume: values.mustVolume,
+                    notes: trimmed(values.notes)
+                });
+                this.handleWorkflowChange({ refreshBatches: false });
+                break;
+            case 'settling-start':
+                this.workflowManager.startSettling(workflowId, {
+                    start: values.start || null,
+                    tankId: trimmed(values.tankId),
+                    expectedHours: values.expectedHours,
+                    notes: trimmed(values.notes)
+                });
+                this.handleWorkflowChange({ refreshBatches: false });
+                break;
+            case 'settling-complete':
+                this.workflowManager.completeSettling(workflowId, {
+                    end: values.end || null,
+                    clarity: trimmed(values.clarity),
+                    notes: trimmed(values.notes)
+                });
+                this.handleWorkflowChange({ refreshBatches: false });
+                break;
+            case 'fermentation-start':
+                this.workflowManager.startFermentation(workflowId, {
+                    inoculatedAt: values.inoculatedAt || null,
+                    tankId: trimmed(values.tankId),
+                    yeast: trimmed(values.yeast),
+                    volume: values.volume,
+                    temperature: values.temperature,
+                    density: values.density,
+                    scale: values.scale,
+                    ph: values.ph,
+                    notes: trimmed(values.notes)
+                });
+                this.handleWorkflowChange({ refreshBatches: true });
+                break;
+            case 'addition':
+                this.workflowManager.recordAddition(workflowId, {
+                    product: trimmed(values.product),
+                    amount: values.amount,
+                    unit: trimmed(values.unit),
+                    stage: values.stage,
+                    notes: trimmed(values.notes)
+                });
+                this.handleWorkflowChange({ refreshBatches: values.stage === 'fermentation' });
+                break;
+            case 'reading':
+                this.workflowManager.recordFermentationReading(workflowId, {
+                    timestamp: values.timestamp || null,
+                    temperature: values.temperature,
+                    density: values.density,
+                    scale: values.scale,
+                    ph: values.ph,
+                    notes: trimmed(values.notes)
+                });
+                this.handleWorkflowChange({ refreshBatches: true, refreshCharts: true });
+                break;
+            case 'burb':
+                this.workflowManager.recordBurbProcessing(workflowId, {
+                    startedAt: values.startedAt || null,
+                    bentoniteAddedAt: values.bentoniteAddedAt || null,
+                    notes: trimmed(values.notes)
+                });
+                this.handleWorkflowChange({ refreshBatches: false });
+                break;
+            default:
+                break;
+        }
+    }
+
+    handleWorkflowChange({ refreshBatches = false, refreshCharts = false } = {}) {
+        this.renderHarvestWorkflowBoard();
+        this.renderActivityFeed();
+        this.updateNotifications();
+        if (refreshBatches) {
+            this.renderBatchOverview();
+            this.renderTankOverview();
+            this.renderKPIs();
+        }
+        if (refreshCharts) {
+            this.renderFermentationProgress();
+            this.renderTemperatureChart();
+        }
+    }
+
+    renderHarvestWorkflowBoard() {
+        const list = document.getElementById('harvestWorkflowList');
+        const emptyState = document.getElementById('harvestWorkflowEmptyState');
+        if (!list || !this.workflowManager) {
+            return;
+        }
+
+        const arrivalInput = document.getElementById('intakeArrival');
+        if (arrivalInput && !arrivalInput.value) {
+            arrivalInput.value = this.formatInputDate(new Date(), true);
+        }
+
+        const workflows = this.workflowManager.getWorkflows();
+        list.innerHTML = '';
+
+        if (!workflows.length) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        this.toggleEmptyState(emptyState, false);
+
+        workflows.sort((a, b) => new Date(b.arrival.time) - new Date(a.arrival.time));
+        workflows.forEach(workflow => {
+            list.appendChild(this.buildWorkflowCard(workflow));
+        });
+    }
+
+    buildWorkflowCard(workflow) {
+        const card = document.createElement('article');
+        card.className = 'glass-card workflow-card';
+        const statusMeta = this.getWorkflowStatusMeta(workflow);
+        const transportLabel = this.formatTransport(workflow.arrival?.vehicleType);
+        const crateInfo = workflow.arrival?.crateCount
+            ? `${this.formatNumber(workflow.arrival.crateCount)} × ${workflow.arrival.crateWeight ?? '—'} kg`
+            : '—';
+        const totalWeight = workflow.arrival?.totalWeight
+            ? `${this.formatNumber(workflow.arrival.totalWeight)} kg`
+            : '—';
+        const plannedVolume = workflow.fermentation?.volume ?? workflow.fermentation?.plannedVolume;
+        const routeLabel = workflow.route === 'press'
+            ? 'Destem • Press • Settling'
+            : 'Destem • Direct fermentation';
+        const fermentationTank = workflow.fermentation?.tankId || 'Not assigned';
+
+        const alerts = [];
+        if (workflow.settling?.start && !workflow.settling?.end) {
+            const elapsed = (Date.now() - new Date(workflow.settling.start).getTime()) / (1000 * 60 * 60);
+            if (Number.isFinite(elapsed) && elapsed > 72) {
+                alerts.push(`Settling active for ${Math.round(elapsed)} h`);
+            }
+        }
+        if (workflow.fermentation?.started) {
+            const readings = workflow.fermentation.readings;
+            const lastReading = Array.isArray(readings) && readings.length ? readings[readings.length - 1] : null;
+            if (!lastReading || (Date.now() - new Date(lastReading.timestamp).getTime()) / (1000 * 60 * 60) > 30) {
+                alerts.push('Capture a fresh fermentation reading');
+            }
+        }
+
+        const header = `
+            <header>
+                <div>
+                    <h3>${this.escapeHtml(workflow.grapes?.variety || 'Unassigned variety')}</h3>
+                    <p class="small-note">${this.escapeHtml(workflow.grapes?.vineyard || 'Vineyard TBD')}${workflow.grapes?.block ? ` • Block ${this.escapeHtml(workflow.grapes.block)}` : ''}</p>
+                </div>
+                <span class="status-pill ${statusMeta.className}">${statusMeta.label}</span>
+            </header>
+        `;
+
+        const meta = `
+            <dl class="workflow-meta">
+                <div>
+                    <dt>Arrival</dt>
+                    <dd>${this.formatDate(workflow.arrival?.time)}</dd>
+                </div>
+                <div>
+                    <dt>Transport</dt>
+                    <dd>${this.escapeHtml(transportLabel)}</dd>
+                </div>
+                <div>
+                    <dt>Crates</dt>
+                    <dd>${crateInfo}</dd>
+                </div>
+                <div>
+                    <dt>Total weight</dt>
+                    <dd>${totalWeight}</dd>
+                </div>
+                <div>
+                    <dt>Route</dt>
+                    <dd>${this.escapeHtml(routeLabel)}</dd>
+                </div>
+                <div>
+                    <dt>Fermentation tank</dt>
+                    <dd>${this.escapeHtml(fermentationTank)}</dd>
+                </div>
+                <div>
+                    <dt>Planned volume</dt>
+                    <dd>${plannedVolume !== null && plannedVolume !== undefined ? `${this.formatNumber(plannedVolume)} L` : '—'}</dd>
+                </div>
+            </dl>
+        `;
+
+        const notesFooter = workflow.arrival?.notes
+            ? `<footer class="small-note">Intake notes: ${this.escapeHtml(workflow.arrival.notes)}</footer>`
+            : '';
+
+        card.innerHTML = [
+            header,
+            alerts.length ? alerts.map(message => `<div class="workflow-alert">${this.escapeHtml(message)}</div>`).join('') : '',
+            meta,
+            this.buildWorkflowProgress(workflow),
+            this.buildWorkflowActions(workflow),
+            this.buildAdditionsSection(workflow),
+            this.buildReadingsSection(workflow),
+            this.buildHistorySection(workflow),
+            notesFooter
+        ].filter(Boolean).join('');
+
+        return card;
+    }
+
+    getWorkflowStatusMeta(workflow) {
+        const defaultMeta = { label: 'In intake', className: 'status-warning' };
+        if (!workflow) {
+            return defaultMeta;
+        }
+        switch (workflow.status) {
+            case 'intake':
+                return { label: 'Awaiting destemming', className: 'status-warning' };
+            case 'destemmed':
+                return { label: workflow.route === 'press' ? 'Ready for pressing' : 'Ready for fermentation', className: 'status-warning' };
+            case 'pressed':
+                return { label: 'Pressed – assign settling tank', className: 'status-warning' };
+            case 'settling':
+                return { label: `Settling in ${workflow.settling?.tankId || 'tank'}`, className: 'status-warning' };
+            case 'settled':
+                return { label: 'Settling complete', className: 'status-active' };
+            case 'fermenting':
+                return { label: `Fermenting in ${workflow.fermentation?.tankId || 'tank'}`, className: 'status-active' };
+            default:
+                return defaultMeta;
+        }
+    }
+
+    formatTransport(type) {
+        switch ((type || '').toLowerCase()) {
+            case 'tractor-trailer':
+                return 'Farm trailer with crates';
+            case 'fiat-ducato':
+                return 'Coachbuilt Fiat Ducato';
+            case 'other':
+                return 'Other transport';
+            default:
+                return type || 'Not recorded';
+        }
+    }
+
+    buildWorkflowProgress(workflow) {
+        if (!workflow) {
+            return '';
+        }
+        const steps = [
+            { id: 'intake', label: 'Transport', completed: true },
+            { id: 'destemming', label: 'Destemming', completed: workflow.destemming?.completed },
+            { id: 'pressing', label: 'Pressing', completed: workflow.route === 'press' ? workflow.pressing?.completed : true, hidden: workflow.route !== 'press' },
+            { id: 'settling', label: 'Settling', completed: workflow.route === 'press' ? Boolean(workflow.settling?.end) : true, inProgress: workflow.settling?.start && !workflow.settling?.end, hidden: workflow.route !== 'press' },
+            { id: 'fermentation', label: 'Fermentation', completed: workflow.fermentation?.started }
+        ].filter(step => !step.hidden);
+
+        const items = steps.map(step => {
+            const classes = [''];
+            if (step.completed) {
+                classes.push('completed');
+            } else if (step.inProgress) {
+                classes.push('in-progress');
+            }
+            return `<li class="${classes.join(' ').trim()}">${step.label}</li>`;
+        }).join('');
+        return `<ol class="workflow-progress">${items}</ol>`;
+    }
+
+    buildWorkflowActions(workflow) {
+        const sections = [];
+        if (!workflow.destemming?.completed) {
+            sections.push(this.buildDestemmingForm(workflow));
+        }
+        if (workflow.route === 'press' && workflow.destemming?.completed && !workflow.pressing?.completed) {
+            sections.push(this.buildPressingForm(workflow));
+        }
+        if (workflow.route === 'press' && workflow.pressing?.completed && !workflow.settling?.start) {
+            sections.push(this.buildSettlingStartForm(workflow));
+        }
+        if (workflow.route === 'press' && workflow.settling?.start && !workflow.settling?.end) {
+            sections.push(this.buildSettlingCompleteForm(workflow));
+        }
+
+        const canStartFermentation = !workflow.fermentation?.started && (
+            workflow.route === 'tank'
+                ? workflow.destemming?.completed
+                : Boolean(workflow.settling?.end)
+        );
+        if (canStartFermentation) {
+            sections.push(this.buildFermentationStartForm(workflow));
+        }
+        if (workflow.fermentation?.started) {
+            sections.push(this.buildFermentationReadingForm(workflow));
+        }
+        sections.push(this.buildAdditionForm(workflow));
+        if (workflow.route === 'press') {
+            sections.push(this.buildBurbForm(workflow));
+        }
+
+        const content = sections.filter(Boolean).join('');
+        return content ? `<div class="workflow-actions">${content}</div>` : '';
+    }
+
+    buildDestemmingForm(workflow) {
+        const timestamp = this.formatInputDate(workflow.destemming?.timestamp, true);
+        const route = workflow.route === 'tank' ? 'tank' : 'press';
+        const estimatedVolume = workflow.fermentation?.plannedVolume ?? '';
+        return `
+            <form class="workflow-action-form" data-action="destemming" data-workflow-id="${workflow.id}">
+                <h4>Destemming &amp; routing</h4>
+                <div class="form-row">
+                    <label for="dest-${workflow.id}">Destemmed at</label>
+                    <input type="datetime-local" id="dest-${workflow.id}" name="timestamp" value="${timestamp}">
+                </div>
+                <div class="fieldset-options">
+                    <div class="option">
+                        <input type="radio" id="dest-route-press-${workflow.id}" name="route" value="press" ${route !== 'tank' ? 'checked' : ''}>
+                        <label for="dest-route-press-${workflow.id}">Press for settling</label>
+                    </div>
+                    <div class="option">
+                        <input type="radio" id="dest-route-tank-${workflow.id}" name="route" value="tank" ${route === 'tank' ? 'checked' : ''}>
+                        <label for="dest-route-tank-${workflow.id}">Send to fermentation tank</label>
+                    </div>
+                </div>
+                <div class="workflow-inline-group">
+                    <div>
+                        <label for="dest-volume-${workflow.id}">Estimated volume (L)</label>
+                        <input type="number" step="0.1" min="0" id="dest-volume-${workflow.id}" name="estimatedVolume" value="${estimatedVolume ?? ''}">
+                    </div>
+                    <div>
+                        <label for="dest-tank-${workflow.id}">Fermentation tank</label>
+                        <select id="dest-tank-${workflow.id}" name="tankId">
+                            ${this.buildTankOptions(workflow.fermentation?.tankId)}
+                        </select>
+                    </div>
+                </div>
+                <div class="form-row">
+                    <label for="dest-notes-${workflow.id}">Notes</label>
+                    <textarea id="dest-notes-${workflow.id}" name="notes">${this.escapeHtml(workflow.destemming?.notes || '')}</textarea>
+                </div>
+                <button type="submit" class="btn-primary">Save destemming</button>
+            </form>
+        `;
+    }
+
+    buildPressingForm(workflow) {
+        const timestamp = this.formatInputDate(workflow.pressing?.timestamp, true);
+        const mustVolume = workflow.pressing?.mustVolume ?? workflow.fermentation?.plannedVolume ?? '';
+        return `
+            <form class="workflow-action-form" data-action="pressing" data-workflow-id="${workflow.id}">
+                <h4>Press cycle</h4>
+                <div class="workflow-inline-group">
+                    <div>
+                        <label for="press-time-${workflow.id}">Press completed</label>
+                        <input type="datetime-local" id="press-time-${workflow.id}" name="timestamp" value="${timestamp}">
+                    </div>
+                    <div>
+                        <label for="press-id-${workflow.id}">Press</label>
+                        <input type="text" id="press-id-${workflow.id}" name="pressId" placeholder="Press ID or cycle" value="${this.escapeHtml(workflow.pressing?.pressId || '')}">
+                    </div>
+                </div>
+                <div class="form-row">
+                    <label for="press-volume-${workflow.id}">Must volume (L)</label>
+                    <input type="number" step="0.1" min="0" id="press-volume-${workflow.id}" name="mustVolume" value="${mustVolume ?? ''}">
+                </div>
+                <div class="form-row">
+                    <label for="press-notes-${workflow.id}">Notes</label>
+                    <textarea id="press-notes-${workflow.id}" name="notes">${this.escapeHtml(workflow.pressing?.notes || '')}</textarea>
+                </div>
+                <button type="submit" class="btn-primary">Record pressing</button>
+            </form>
+        `;
+    }
+
+    buildSettlingStartForm(workflow) {
+        const start = this.formatInputDate(workflow.settling?.start, true);
+        const expected = workflow.settling?.expectedHours ?? '';
+        return `
+            <form class="workflow-action-form" data-action="settling-start" data-workflow-id="${workflow.id}">
+                <h4>Start settling</h4>
+                <div class="workflow-inline-group">
+                    <div>
+                        <label for="settling-start-${workflow.id}">Start</label>
+                        <input type="datetime-local" id="settling-start-${workflow.id}" name="start" value="${start}">
+                    </div>
+                    <div>
+                        <label for="settling-tank-${workflow.id}">Settling tank</label>
+                        <select id="settling-tank-${workflow.id}" name="tankId">
+                            ${this.buildTankOptions(workflow.settling?.tankId || 'R1')}
+                        </select>
+                    </div>
+                </div>
+                <div class="form-row">
+                    <label for="settling-hours-${workflow.id}">Expected duration (h)</label>
+                    <input type="number" min="0" step="0.5" id="settling-hours-${workflow.id}" name="expectedHours" value="${expected ?? ''}">
+                </div>
+                <div class="form-row">
+                    <label for="settling-notes-${workflow.id}">Notes</label>
+                    <textarea id="settling-notes-${workflow.id}" name="notes">${this.escapeHtml(workflow.settling?.notes || '')}</textarea>
+                </div>
+                <button type="submit" class="btn-primary">Begin settling</button>
+            </form>
+        `;
+    }
+
+    buildSettlingCompleteForm(workflow) {
+        const end = this.formatInputDate(workflow.settling?.end, true);
+        return `
+            <form class="workflow-action-form" data-action="settling-complete" data-workflow-id="${workflow.id}">
+                <h4>Complete settling</h4>
+                <div class="form-row">
+                    <label for="settling-end-${workflow.id}">Completed at</label>
+                    <input type="datetime-local" id="settling-end-${workflow.id}" name="end" value="${end}">
+                </div>
+                <div class="workflow-inline-group">
+                    <div>
+                        <label for="settling-clarity-${workflow.id}">Clarity</label>
+                        <input type="text" id="settling-clarity-${workflow.id}" name="clarity" placeholder="e.g. NTU" value="${this.escapeHtml(workflow.settling?.clarity || '')}">
+                    </div>
+                    <div>
+                        <label for="settling-complete-notes-${workflow.id}">Notes</label>
+                        <input type="text" id="settling-complete-notes-${workflow.id}" name="notes" value="${this.escapeHtml(workflow.settling?.notes || '')}">
+                    </div>
+                </div>
+                <button type="submit" class="btn-primary">Log completion</button>
+            </form>
+        `;
+    }
+
+    buildFermentationStartForm(workflow) {
+        const inoculation = this.formatInputDate(workflow.fermentation?.inoculatedAt, true);
+        const scale = workflow.fermentation?.densityScale || 'Brix';
+        const planned = workflow.fermentation?.volume ?? workflow.fermentation?.plannedVolume ?? '';
+        return `
+            <form class="workflow-action-form" data-action="fermentation-start" data-workflow-id="${workflow.id}">
+                <h4>Start fermentation</h4>
+                <div class="workflow-inline-group">
+                    <div>
+                        <label for="ferm-date-${workflow.id}">Inoculated at</label>
+                        <input type="datetime-local" id="ferm-date-${workflow.id}" name="inoculatedAt" value="${inoculation}">
+                    </div>
+                    <div>
+                        <label for="ferm-tank-${workflow.id}">Fermentation tank</label>
+                        <select id="ferm-tank-${workflow.id}" name="tankId">
+                            ${this.buildTankOptions(workflow.fermentation?.tankId)}
+                        </select>
+                    </div>
+                </div>
+                <div class="workflow-inline-group">
+                    <div>
+                        <label for="ferm-yeast-${workflow.id}">Yeast</label>
+                        <input type="text" id="ferm-yeast-${workflow.id}" name="yeast" placeholder="Inoculated yeast" value="${this.escapeHtml(workflow.fermentation?.yeast || '')}">
+                    </div>
+                    <div>
+                        <label for="ferm-volume-${workflow.id}">Volume (L)</label>
+                        <input type="number" min="0" step="0.1" id="ferm-volume-${workflow.id}" name="volume" value="${planned ?? ''}">
+                    </div>
+                </div>
+                <div class="workflow-inline-group">
+                    <div>
+                        <label for="ferm-density-${workflow.id}">Density</label>
+                        <input type="number" step="0.01" id="ferm-density-${workflow.id}" name="density" value="${workflow.fermentation?.startingDensity ?? ''}">
+                    </div>
+                    <div>
+                        <label for="ferm-scale-${workflow.id}">Scale</label>
+                        <select id="ferm-scale-${workflow.id}" name="scale">
+                            ${['Brix', 'Baumé', 'g/L', 'Babo'].map(option => `<option value="${option}" ${option === scale ? 'selected' : ''}>${option}</option>`).join('')}
+                        </select>
+                    </div>
+                    <div>
+                        <label for="ferm-temp-${workflow.id}">Temperature (°C)</label>
+                        <input type="number" step="0.1" id="ferm-temp-${workflow.id}" name="temperature" value="${workflow.fermentation?.startingTemperature ?? ''}">
+                    </div>
+                    <div>
+                        <label for="ferm-ph-${workflow.id}">pH</label>
+                        <input type="number" step="0.01" id="ferm-ph-${workflow.id}" name="ph" value="${workflow.fermentation?.startingPh ?? ''}">
+                    </div>
+                </div>
+                <div class="form-row">
+                    <label for="ferm-notes-${workflow.id}">Notes</label>
+                    <textarea id="ferm-notes-${workflow.id}" name="notes">${this.escapeHtml(workflow.fermentation?.notes || '')}</textarea>
+                </div>
+                <button type="submit" class="btn-primary">Start fermentation</button>
+            </form>
+        `;
+    }
+
+    buildFermentationReadingForm(workflow) {
+        const timestamp = this.formatInputDate(null, true);
+        return `
+            <form class="workflow-action-form" data-action="reading" data-workflow-id="${workflow.id}">
+                <h4>Fermentation reading</h4>
+                <div class="workflow-inline-group">
+                    <div>
+                        <label for="reading-time-${workflow.id}">Recorded at</label>
+                        <input type="datetime-local" id="reading-time-${workflow.id}" name="timestamp" value="${timestamp}">
+                    </div>
+                    <div>
+                        <label for="reading-density-${workflow.id}">Density</label>
+                        <input type="number" step="0.01" id="reading-density-${workflow.id}" name="density">
+                    </div>
+                    <div>
+                        <label for="reading-scale-${workflow.id}">Scale</label>
+                        <select id="reading-scale-${workflow.id}" name="scale">
+                            ${['Brix', 'Baumé', 'g/L', 'Babo'].map(option => `<option value="${option}" ${option === (workflow.fermentation?.densityScale || 'Brix') ? 'selected' : ''}>${option}</option>`).join('')}
+                        </select>
+                    </div>
+                </div>
+                <div class="workflow-inline-group">
+                    <div>
+                        <label for="reading-temp-${workflow.id}">Temperature (°C)</label>
+                        <input type="number" step="0.1" id="reading-temp-${workflow.id}" name="temperature">
+                    </div>
+                    <div>
+                        <label for="reading-ph-${workflow.id}">pH</label>
+                        <input type="number" step="0.01" id="reading-ph-${workflow.id}" name="ph">
+                    </div>
+                </div>
+                <div class="form-row">
+                    <label for="reading-notes-${workflow.id}">Notes</label>
+                    <textarea id="reading-notes-${workflow.id}" name="notes" placeholder="Cap management, aromas, etc."></textarea>
+                </div>
+                <button type="submit" class="btn-primary">Log reading</button>
+            </form>
+        `;
+    }
+
+    buildAdditionForm(workflow) {
+        return `
+            <form class="workflow-action-form" data-action="addition" data-workflow-id="${workflow.id}">
+                <h4>Add enological product</h4>
+                <div class="workflow-inline-group">
+                    <div>
+                        <label for="addition-product-${workflow.id}">Product</label>
+                        <select id="addition-product-${workflow.id}" name="product">
+                            ${['SO₂ / KMS', 'Tannins', 'Enzymes', 'Tartaric acid', 'Nutrients', 'Bentonite', 'Other'].map(option => `<option value="${option}">${option}</option>`).join('')}
+                        </select>
+                    </div>
+                    <div>
+                        <label for="addition-amount-${workflow.id}">Amount</label>
+                        <input type="number" step="0.01" id="addition-amount-${workflow.id}" name="amount" placeholder="Quantity">
+                    </div>
+                    <div>
+                        <label for="addition-unit-${workflow.id}">Unit</label>
+                        <input type="text" id="addition-unit-${workflow.id}" name="unit" placeholder="e.g. g/hL">
+                    </div>
+                </div>
+                <div class="workflow-inline-group">
+                    <div>
+                        <label for="addition-stage-${workflow.id}">Stage</label>
+                        <select id="addition-stage-${workflow.id}" name="stage">
+                            ${['destemming', 'must', 'settling', 'fermentation', 'burb'].map(stage => `<option value="${stage}">${stage.charAt(0).toUpperCase()}${stage.slice(1)}</option>`).join('')}
+                        </select>
+                    </div>
+                    <div>
+                        <label for="addition-notes-${workflow.id}">Notes</label>
+                        <input type="text" id="addition-notes-${workflow.id}" name="notes" placeholder="Vendor, batch, reason">
+                    </div>
+                </div>
+                <button type="submit" class="btn-primary">Log addition</button>
+            </form>
+        `;
+    }
+
+    buildBurbForm(workflow) {
+        return `
+            <form class="workflow-action-form" data-action="burb" data-workflow-id="${workflow.id}">
+                <h4>Lees (burb) management</h4>
+                <div class="workflow-inline-group">
+                    <div>
+                        <label for="burb-start-${workflow.id}">Fermentation start</label>
+                        <input type="datetime-local" id="burb-start-${workflow.id}" name="startedAt" value="${this.formatInputDate(workflow.burb?.startedAt, !!workflow.burb?.startedAt)}">
+                    </div>
+                    <div>
+                        <label for="burb-bentonite-${workflow.id}">Bentonite added</label>
+                        <input type="datetime-local" id="burb-bentonite-${workflow.id}" name="bentoniteAddedAt" value="${this.formatInputDate(workflow.burb?.bentoniteAddedAt, false)}">
+                    </div>
+                </div>
+                <div class="form-row">
+                    <label for="burb-notes-${workflow.id}">Notes</label>
+                    <textarea id="burb-notes-${workflow.id}" name="notes">${this.escapeHtml(workflow.burb?.notes || '')}</textarea>
+                </div>
+                <button type="submit" class="btn-primary">Update lees plan</button>
+            </form>
+        `;
+    }
+
+    buildAdditionsSection(workflow) {
+        const additions = Array.isArray(workflow.additions) ? [...workflow.additions] : [];
+        if (!additions.length) {
+            return '';
+        }
+        additions.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+        const items = additions.slice(0, 6).map(addition => {
+            const amountValue = addition.amount !== null && addition.amount !== undefined
+                ? this.formatNumber(addition.amount)
+                : null;
+            const amount = amountValue !== null && amountValue !== undefined
+                ? `${amountValue} ${this.escapeHtml(addition.unit || '')}`.trim()
+                : this.escapeHtml(addition.unit || '');
+            return `
+                <li>
+                    <strong>${this.escapeHtml(addition.product || 'Addition')}</strong>
+                    <span class="small-note">${this.formatDate(addition.timestamp)} • ${this.escapeHtml(addition.stage)}</span>
+                    ${amount ? `<div class="small-note">${amount}</div>` : ''}
+                    ${addition.notes ? `<div class="small-note">${this.escapeHtml(addition.notes)}</div>` : ''}
+                </li>
+            `;
+        }).join('');
+        return `<div class="workflow-subsection"><h4>Enological additions</h4><ul class="workflow-additions">${items}</ul></div>`;
+    }
+
+    buildReadingsSection(workflow) {
+        const readings = Array.isArray(workflow.fermentation?.readings) ? [...workflow.fermentation.readings] : [];
+        if (!readings.length) {
+            return '';
+        }
+        readings.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+        const rows = readings.slice(0, 6).map(reading => `
+            <tr>
+                <td>${this.formatDate(reading.timestamp)}</td>
+                <td>${reading.density !== null && reading.density !== undefined ? `${this.formatNumber(reading.density)} ${this.escapeHtml(reading.scale || '')}` : '—'}</td>
+                <td>${reading.temperature !== null && reading.temperature !== undefined ? `${this.formatNumber(reading.temperature)} °C` : '—'}</td>
+                <td>${reading.ph !== null && reading.ph !== undefined ? this.formatNumber(reading.ph) : '—'}</td>
+                <td>${this.escapeHtml(reading.notes || '')}</td>
+            </tr>
+        `).join('');
+        return `
+            <div class="workflow-subsection">
+                <h4>Fermentation readings</h4>
+                <table class="workflow-table">
+                    <thead>
+                        <tr><th>Date</th><th>Density</th><th>Temp</th><th>pH</th><th>Notes</th></tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>
+            </div>
+        `;
+    }
+
+    buildHistorySection(workflow) {
+        const history = Array.isArray(workflow.history) ? [...workflow.history] : [];
+        if (!history.length) {
+            return '';
+        }
+        history.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+        const items = history.slice(0, 5).map(entry => `
+            <li>
+                <strong>${this.escapeHtml(entry.summary || entry.type || 'Update')}</strong>
+                <div class="small-note">${this.formatDate(entry.timestamp)}</div>
+                ${entry.detail ? `<div class="small-note">${this.escapeHtml(entry.detail)}</div>` : ''}
+            </li>
+        `).join('');
+        return `<div class="workflow-subsection"><h4>Latest activity</h4><ul class="workflow-history">${items}</ul></div>`;
+    }
+
+    buildTankOptions(selectedId) {
+        if (!Array.isArray(this.tanks) || !this.tanks.length) {
+            return '<option value="">No tanks configured</option>';
+        }
+        const options = ['<option value="">Select tank</option>'];
+        this.tanks.forEach(tank => {
+            const description = tank.description ? ` – ${this.escapeHtml(tank.description)}` : '';
+            const selected = tank.id === selectedId ? 'selected' : '';
+            options.push(`<option value="${this.escapeHtml(tank.id)}" ${selected}>${this.escapeHtml(tank.id)}${description}</option>`);
+        });
+        return options.join('');
+    }
+
+    formatInputDate(value, fallbackNow = false) {
+        if (value) {
+            try {
+                return typeof formatForDateTimeInput === 'function'
+                    ? formatForDateTimeInput(value)
+                    : new Date(value).toISOString().slice(0, 16);
+            } catch (error) {
+                // ignore formatting issues and fall through
+            }
+        }
+        if (fallbackNow) {
+            const now = new Date();
+            return typeof formatForDateTimeInput === 'function'
+                ? formatForDateTimeInput(now)
+                : now.toISOString().slice(0, 16);
+        }
+        return '';
+    }
+
+    escapeHtml(value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value).replace(/[&<>"']/g, (char) => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;'
+        })[char] || char);
     }
 
     renderKPIs() {
@@ -112,26 +960,713 @@ class EnhancedDashboardApp {
         }
     }
 
+    switchView(view) {
+        const target = view || 'dashboard';
+        this.currentView = target;
+
+        const navItems = document.querySelectorAll('.nav-menu .nav-item[data-view]');
+        navItems.forEach(item => {
+            const isActive = item.dataset.view === target;
+            item.classList.toggle('active', isActive);
+            if (isActive) {
+                item.setAttribute('aria-current', 'page');
+            } else {
+                item.removeAttribute('aria-current');
+            }
+        });
+
+        let matched = false;
+        const panels = document.querySelectorAll('.view-panel[data-view]');
+        panels.forEach(panel => {
+            const isMatch = panel.dataset.view === target;
+            panel.classList.toggle('active', isMatch);
+            panel.setAttribute('aria-hidden', isMatch ? 'false' : 'true');
+            if (isMatch) {
+                matched = true;
+            }
+        });
+
+        if (!matched) {
+            return;
+        }
+
+        switch (target) {
+            case 'dashboard':
+                this.renderKPIs();
+                this.renderCellarMap();
+                this.renderTemperatureChart();
+                this.renderFermentationProgress();
+                this.renderActivityFeed();
+                this.renderTimeline();
+                break;
+            case 'tanks':
+                this.renderTankOverview();
+                break;
+            case 'batches':
+                this.renderBatchOverview();
+                break;
+            case 'laboratory':
+                this.renderLabOverview();
+                break;
+            case 'production':
+                this.renderProductionSchedule();
+                this.renderHarvestWorkflowBoard();
+                break;
+            case 'analytics':
+                this.renderAnalyticsSummary();
+                break;
+            case 'settings':
+                this.renderSettingsPanel();
+                break;
+            default:
+                break;
+        }
+
+        this.toggleNotifications(false);
+    }
+
     renderCellarMap() {
-        if (!this.productionPlanner) return;
-        const map = this.productionPlanner.generateCellarMap();
         const container = document.getElementById('cellarVisualization');
         if (!container) return;
+        const toggleButton = document.querySelector('[data-action="toggle-3d"]');
+        if (toggleButton) {
+            toggleButton.textContent = this.cellar3DEnabled ? '2D View' : '3D View';
+            toggleButton.setAttribute('aria-pressed', String(this.cellar3DEnabled));
+        }
+
         container.innerHTML = '';
+        if (this.cellar3DEnabled) {
+            this.renderCellar3D(container);
+            return;
+        }
+
+        const map = this.productionPlanner ? this.productionPlanner.generateCellarMap() : { tanks: [] };
+        const plannerTanks = Array.isArray(map.tanks) && map.tanks.length > 0 ? map.tanks : [];
+        const tanks = plannerTanks.length ? plannerTanks : this.tanks.map(tank => ({
+            id: tank.id,
+            location: tank.location ?? 'Cellar',
+            fillLevel: 0,
+            temperature: null,
+            capacity: tank.capacity
+        }));
+
+        if (!tanks.length) {
+            const empty = document.createElement('div');
+            empty.className = 'empty-state glass-card';
+            empty.innerHTML = '<h3>No tanks available</h3><p>Add tanks to visualize your cellar layout.</p>';
+            container.appendChild(empty);
+            return;
+        }
+
         const grid = document.createElement('div');
         grid.className = 'tank-grid';
-        map.tanks.forEach(tank => {
+        tanks.forEach(tank => {
             const card = document.createElement('div');
             card.className = 'glass-card';
+            const fillLevel = typeof tank.fillLevel === 'number' ? tank.fillLevel : 0;
             card.innerHTML = `
                 <h3>${tank.id}</h3>
-                <p>Location: ${tank.location}</p>
-                <p>Fill Level: ${tank.fillLevel.toFixed(1)}%</p>
-                <p>Temperature: ${tank.temperature ?? 'N/A'}°C</p>
+                <p>Location: ${tank.location ?? '—'}</p>
+                <p>Fill Level: ${fillLevel.toFixed(1)}%</p>
+                <p>Temperature: ${tank.temperature != null ? `${tank.temperature}°C` : 'N/A'}</p>
             `;
             grid.appendChild(card);
         });
         container.appendChild(grid);
+    }
+
+    renderCellar3D(container) {
+        const stage = document.createElement('div');
+        stage.className = 'cellar-3d';
+        const tanks = this.tanks.length ? this.tanks : (this.productionPlanner?.resources?.tanks ?? []);
+
+        if (!tanks.length) {
+            const empty = document.createElement('div');
+            empty.className = 'empty-state glass-card';
+            empty.innerHTML = '<h3>No tanks to display</h3><p>Add tanks to experience the 3D cellar view.</p>';
+            container.appendChild(empty);
+            return;
+        }
+
+        const batchesByTank = new Map();
+        if (this.batchManager) {
+            this.batchManager.getAllBatches().forEach(batch => {
+                if (batch.currentTank) {
+                    batchesByTank.set(batch.currentTank, batch);
+                }
+            });
+        }
+
+        tanks.slice(0, 12).forEach(tank => {
+            const card = document.createElement('div');
+            card.className = 'cellar-3d__tank glass-card';
+            const assigned = batchesByTank.get(tank.id);
+            const capacity = Number(tank.capacity ?? 0);
+            const currentVolume = Number.isFinite(assigned?.currentVolume)
+                ? Number(assigned.currentVolume)
+                : Number.isFinite(assigned?.initialVolume)
+                    ? Number(assigned.initialVolume)
+                    : null;
+            const fillPercent = capacity > 0 && currentVolume != null
+                ? Math.max(0, Math.min(100, Math.round((currentVolume / capacity) * 100)))
+                : 0;
+
+            card.innerHTML = `
+                <div>
+                    <h3>${tank.id}</h3>
+                    <p class="cellar-3d__meta">${assigned ? `${assigned.variety ?? 'Blend'} • ${assigned.status ?? 'active'}` : (tank.location ?? 'Available')}</p>
+                </div>
+                <div class="cellar-3d__level">
+                    <div class="cellar-3d__level-fill" style="height:${fillPercent}%"></div>
+                </div>
+                <p class="cellar-3d__meta">${capacity ? `${capacity.toLocaleString()} L capacity` : ''}</p>
+            `;
+            stage.appendChild(card);
+        });
+
+        container.appendChild(stage);
+    }
+
+    renderTankOverview() {
+        const container = document.getElementById('tankOverviewList');
+        const emptyState = document.getElementById('tanksEmptyState');
+        if (!container) {
+            return;
+        }
+        container.innerHTML = '';
+
+        if (!Array.isArray(this.tanks) || this.tanks.length === 0) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        this.toggleEmptyState(emptyState, false);
+
+        const batchesByTank = new Map();
+        if (this.batchManager) {
+            this.batchManager.getAllBatches().forEach(batch => {
+                if (batch.currentTank) {
+                    batchesByTank.set(batch.currentTank, batch);
+                }
+            });
+        }
+
+        this.tanks.forEach(tank => {
+            const card = document.createElement('article');
+            card.className = 'glass-card tank-overview-card';
+            const assigned = batchesByTank.get(tank.id);
+            const capacity = Number(tank.capacity ?? 0);
+            const currentVolume = Number.isFinite(assigned?.currentVolume)
+                ? Number(assigned.currentVolume)
+                : Number.isFinite(assigned?.initialVolume)
+                    ? Number(assigned.initialVolume)
+                    : null;
+            const latest = this.dataManager ? this.dataManager.getLatestReading(tank.id) : null;
+            const fillPercent = capacity > 0 && currentVolume != null
+                ? Math.max(0, Math.min(100, Math.round((currentVolume / capacity) * 100)))
+                : null;
+
+            const capacityText = this.formatNumber(capacity);
+            const volumeText = currentVolume != null ? this.formatNumber(currentVolume) : null;
+            const temperatureText = typeof latest?.temperature === 'number'
+                ? `${latest.temperature}°C`
+                : latest?.temperature != null
+                    ? `${latest.temperature}`
+                    : '—';
+            const sugarValue = latest?.sugar;
+            const sugarText = sugarValue != null ? `${sugarValue}` : '—';
+
+            const metrics = [
+                { label: 'Capacity', value: capacityText ? `${capacityText} L` : '—' },
+                { label: 'Volume', value: volumeText ? `${volumeText} L` : '—' },
+                { label: 'Temperature', value: temperatureText },
+                { label: 'Sugar', value: sugarText }
+            ];
+
+            card.innerHTML = `
+                <header>
+                    <h3>${tank.id}</h3>
+                    <span class="status-pill ${assigned ? 'status-active' : 'status-idle'}">${assigned ? 'Active' : 'Available'}</span>
+                </header>
+                <p class="tank-details">${tank.description || 'No description provided.'}</p>
+                <p class="tank-current-batch">Current batch: ${assigned ? `${assigned.variety ?? 'Blend'} ${assigned.vintage ?? ''}`.trim() || assigned.id : 'None assigned'}</p>
+                <dl class="metric-list">
+                    ${metrics.map(metric => `<div><dt>${metric.label}</dt><dd>${metric.value}</dd></div>`).join('')}
+                </dl>
+                <p class="tank-last-reading">Last reading: ${latest?.timestamp ? this.formatDate(latest.timestamp) : 'No readings yet'}</p>
+                ${fillPercent != null ? `<div class="progress"><div class="progress-bar" style="width:${fillPercent}%"></div></div><p class="progress-label">${fillPercent}% full</p>` : ''}
+            `;
+
+            container.appendChild(card);
+        });
+    }
+
+    renderBatchOverview() {
+        const container = document.getElementById('batchOverviewList');
+        const emptyState = document.getElementById('batchesEmptyState');
+        if (!container) {
+            return;
+        }
+        container.innerHTML = '';
+        const batches = this.batchManager ? this.batchManager.getAllBatches() : [];
+
+        if (!batches.length) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        this.toggleEmptyState(emptyState, false);
+
+        batches.forEach(batch => {
+            const card = document.createElement('article');
+            card.className = 'glass-card batch-overview-card';
+            const status = (batch.status ?? 'active').toLowerCase();
+            let statusClass = 'status-idle';
+            if (status === 'active') {
+                statusClass = 'status-active';
+            } else if (status === 'completed' || status === 'bottled') {
+                statusClass = 'status-success';
+            } else if (status === 'at-risk' || status === 'hold') {
+                statusClass = 'status-warning';
+            }
+
+            const labCount = batch.labResults?.length ?? 0;
+            const historyCount = batch.history?.length ?? 0;
+            const volumeNumber = Number.isFinite(batch.currentVolume) ? Number(batch.currentVolume) : null;
+            const currentVolume = volumeNumber != null
+                ? `${this.formatNumber(volumeNumber) ?? volumeNumber} L`
+                : '—';
+
+            card.innerHTML = `
+                <header>
+                    <h3>${batch.variety ?? 'Batch'} ${batch.vintage ?? ''}</h3>
+                    <span class="status-pill ${statusClass}">${(batch.status ?? 'ACTIVE').toUpperCase()}</span>
+                </header>
+                <p>Batch ID: ${batch.id}</p>
+                <dl class="metric-list">
+                    <div><dt>Volume</dt><dd>${currentVolume}</dd></div>
+                    <div><dt>Tank</dt><dd>${batch.currentTank ?? 'Unassigned'}</dd></div>
+                    <div><dt>Lab Tests</dt><dd>${labCount}</dd></div>
+                    <div><dt>History Events</dt><dd>${historyCount}</dd></div>
+                </dl>
+                <footer>Last updated: ${this.formatDate(batch.history?.[historyCount - 1]?.timestamp ?? batch.createdAt)}</footer>
+            `;
+
+            container.appendChild(card);
+        });
+    }
+
+    renderLabOverview() {
+        const container = document.getElementById('labResultsList');
+        const emptyState = document.getElementById('labEmptyState');
+        if (!container) {
+            return;
+        }
+        container.innerHTML = '';
+
+        if (!this.batchManager) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        const results = this.batchManager.getAllBatches()
+            .map(batch => {
+                const labResults = Array.isArray(batch.labResults) ? [...batch.labResults] : [];
+                if (!labResults.length) {
+                    return null;
+                }
+                const sorted = labResults.sort((a, b) => new Date(b.timestamp ?? b.date ?? 0) - new Date(a.timestamp ?? a.date ?? 0));
+                return { batch, result: sorted[0] };
+            })
+            .filter(Boolean);
+
+        if (!results.length) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        this.toggleEmptyState(emptyState, false);
+
+        results.slice(0, 6).forEach(entry => {
+            const { batch, result } = entry;
+            const quality = result.qualityScore?.score ?? result.qualityScore ?? batch.qualityScore ?? null;
+            const metrics = [
+                { label: 'Alcohol', value: result.alcohol != null ? `${result.alcohol}%` : '—' },
+                { label: 'pH', value: result.pH ?? result.ph ?? '—' },
+                { label: 'TA', value: result.totalAcidity ?? result.ta ?? '—' },
+                { label: 'VA', value: result.volatileAcidity ?? result.va ?? '—' }
+            ];
+
+            const card = document.createElement('article');
+            card.className = 'glass-card lab-overview-card';
+            card.innerHTML = `
+                <header>
+                    <h3>${batch.variety ?? 'Batch'} ${batch.vintage ?? ''}</h3>
+                    ${quality != null ? `<span class="status-pill status-active">Score ${quality}</span>` : ''}
+                </header>
+                <p>Sample ID: ${result.sampleId ?? result.id ?? 'N/A'}</p>
+                <dl class="metric-list">
+                    ${metrics.map(metric => `<div><dt>${metric.label}</dt><dd>${metric.value}</dd></div>`).join('')}
+                </dl>
+                <footer>Result date: ${this.formatDate(result.timestamp ?? result.date)}</footer>
+            `;
+            container.appendChild(card);
+        });
+    }
+
+    renderProductionSchedule() {
+        const container = document.getElementById('productionSchedule');
+        const emptyState = document.getElementById('productionEmptyState');
+        if (!container) {
+            return;
+        }
+        container.innerHTML = '';
+
+        if (!this.productionPlanner) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        const plan = this.productionPlanner.createProductionPlan(new Date().getFullYear());
+        if (!plan?.phases?.length) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        this.toggleEmptyState(emptyState, false);
+
+        plan.phases.forEach(phase => {
+            const card = document.createElement('article');
+            card.className = 'glass-card production-card';
+            card.innerHTML = `
+                <header>
+                    <h3>${phase.name}</h3>
+                    <span class="status-pill status-planned">${(phase.status ?? 'planned').toUpperCase()}</span>
+                </header>
+                <p>${this.formatDate(phase.startDate)} – ${this.formatDate(phase.endDate)}</p>
+                <ul>
+                    ${(phase.resources ?? []).map(resource => {
+                        if (resource.tankId) return `<li>Tank ${resource.tankId}</li>`;
+                        if (resource.barrelId) return `<li>Barrel ${resource.barrelId}</li>`;
+                        if (resource.crewId) return `<li>${resource.crewId}</li>`;
+                        if (resource.role) return `<li>${resource.role}</li>`;
+                        return '';
+                    }).join('')}
+                </ul>
+            `;
+            container.appendChild(card);
+        });
+
+        if (plan.optimization?.suggestions?.length) {
+            const summary = document.createElement('article');
+            summary.className = 'glass-card production-card';
+            summary.innerHTML = `
+                <header>
+                    <h3>Optimization Insights</h3>
+                    <span class="status-pill status-active">Utilization</span>
+                </header>
+                <ul class="suggestions-list">
+                    ${plan.optimization.suggestions.map(suggestion => `<li>${suggestion}</li>`).join('')}
+                </ul>
+                <footer>Crews: ${Math.round(plan.optimization.resourceUtilization.crews)}% • Tanks: ${Math.round(plan.optimization.resourceUtilization.tanks)}% • Barrels: ${Math.round(plan.optimization.resourceUtilization.barrels)}%</footer>
+            `;
+            container.appendChild(summary);
+        }
+    }
+
+    renderAnalyticsSummary() {
+        const container = document.getElementById('analyticsSummary');
+        const emptyState = document.getElementById('analyticsEmptyState');
+        if (!container) {
+            return;
+        }
+        container.innerHTML = '';
+
+        if (!this.aiAnalytics || !this.dataManager || !this.tanks.length) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        const cards = [];
+        this.tanks.slice(0, 6).forEach(tank => {
+            const prediction = this.aiAnalytics.predictFermentationCompletion(tank.id, this.dataManager);
+            if (!prediction) {
+                return;
+            }
+            const risks = Array.isArray(prediction.riskFactors) && prediction.riskFactors.length
+                ? prediction.riskFactors
+                : ['No critical risks detected'];
+            const recommendations = Array.isArray(prediction.recommendations) ? prediction.recommendations : [];
+
+            const card = document.createElement('article');
+            card.className = 'glass-card analytics-card';
+            card.innerHTML = `
+                <header>
+                    <h3>${tank.id}</h3>
+                    <span class="status-pill ${prediction.daysRemaining > 14 ? 'status-warning' : 'status-active'}">${prediction.daysRemaining} days remaining</span>
+                </header>
+                <p>Confidence: ${(prediction.confidence * 100).toFixed(0)}%</p>
+                <ul>
+                    ${risks.map(risk => `<li>${risk}</li>`).join('')}
+                </ul>
+                <footer>${recommendations.length ? (recommendations[0].action ?? recommendations[0]) : 'Monitoring stable fermentation.'}</footer>
+            `;
+            cards.push(card);
+        });
+
+        if (!cards.length) {
+            this.toggleEmptyState(emptyState, true);
+            return;
+        }
+
+        this.toggleEmptyState(emptyState, false);
+        cards.forEach(card => container.appendChild(card));
+    }
+
+    renderSettingsPanel() {
+        const container = document.getElementById('settingsPanel');
+        if (!container) {
+            return;
+        }
+        container.innerHTML = '';
+
+        const features = [
+            {
+                name: 'Offline Sync',
+                description: 'Capture readings without connectivity and sync automatically.',
+                active: !!this.pwaManager,
+                detail: this.pwaManager?.backgroundSyncSupported
+                    ? 'Background sync ready'
+                    : 'Using local queue until connection is restored',
+                statusClass: this.pwaManager ? 'status-active' : 'status-idle'
+            },
+            {
+                name: 'Barcode Scanner',
+                description: 'Use your device camera to scan tank QR codes.',
+                active: !!this.pwaManager?.barcodeDetector,
+                detail: this.pwaManager?.barcodeDetector
+                    ? 'BarcodeDetector API available'
+                    : 'Detector not supported in this browser',
+                statusClass: this.pwaManager?.barcodeDetector ? 'status-active' : 'status-warning'
+            },
+            {
+                name: 'ERP Integration',
+                description: 'Sync inventory and production data with ERP systems.',
+                active: !!this.apiIntegration,
+                detail: this.apiIntegration ? 'Endpoints configured' : 'Integration not connected',
+                statusClass: this.apiIntegration ? 'status-active' : 'status-idle'
+            },
+            {
+                name: 'AI Analytics',
+                description: 'Predict fermentation completion and highlight risks.',
+                active: !!this.aiAnalytics,
+                detail: this.aiAnalytics ? 'Model loaded' : 'Analytics module unavailable',
+                statusClass: this.aiAnalytics ? 'status-active' : 'status-warning'
+            }
+        ];
+
+        features.forEach(feature => {
+            const card = document.createElement('article');
+            card.className = 'glass-card settings-card';
+            card.innerHTML = `
+                <header>
+                    <h3>${feature.name}</h3>
+                    <span class="status-pill ${feature.statusClass}">${feature.active ? 'Enabled' : 'Unavailable'}</span>
+                </header>
+                <p>${feature.description}</p>
+                <footer>${feature.detail}</footer>
+            `;
+            container.appendChild(card);
+        });
+    }
+
+    toggleEmptyState(element, show) {
+        if (!element) {
+            return;
+        }
+        element.hidden = !show;
+        element.setAttribute('aria-hidden', show ? 'false' : 'true');
+    }
+
+    formatNumber(value) {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return value.toLocaleString();
+        }
+        if (typeof value === 'string' && value.trim() !== '' && !Number.isNaN(Number(value))) {
+            return Number(value).toLocaleString();
+        }
+        return null;
+    }
+
+    formatDate(value) {
+        if (!value) {
+            return '—';
+        }
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return value;
+        }
+        return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+    }
+
+    buildNotificationData() {
+        const notifications = [];
+        const now = new Date();
+
+        if (!this.tanks.length) {
+            notifications.push({
+                type: 'action',
+                message: 'Add tanks to begin monitoring your cellar.',
+                detail: 'Import a layout or create tanks from the Tanks view.',
+                time: 'Just now'
+            });
+        } else if (this.dataManager) {
+            const stale = this.tanks.filter(tank => {
+                const latest = this.dataManager.getLatestReading(tank.id);
+                if (!latest || !latest.timestamp) {
+                    return true;
+                }
+                const age = now - new Date(latest.timestamp);
+                return Number.isFinite(age) && age > 1000 * 60 * 60 * 24 * 2;
+            });
+            if (stale.length) {
+                notifications.push({
+                    type: 'warning',
+                    message: `${stale.length} tank${stale.length === 1 ? '' : 's'} need new readings.`,
+                    detail: 'Capture temperature and sugar updates to keep analytics accurate.',
+                    time: 'Today'
+                });
+            }
+        }
+
+        const batches = this.batchManager ? this.batchManager.getAllBatches() : [];
+        if (batches.length) {
+            const active = batches.filter(batch => (batch.status ?? 'active').toLowerCase() === 'active');
+            if (active.length) {
+                notifications.push({
+                    type: 'info',
+                    message: `${active.length} active fermentation${active.length === 1 ? '' : 's'} in progress.`,
+                    detail: 'Review AI forecasts in the Analytics view.',
+                    time: 'Today'
+                });
+            }
+            const missingLab = batches.filter(batch => (batch.labResults?.length ?? 0) === 0);
+            if (missingLab.length) {
+                notifications.push({
+                    type: 'action',
+                    message: `${missingLab.length} batch${missingLab.length === 1 ? '' : 'es'} awaiting lab results.`,
+                    detail: 'Log lab analyses to keep compliance reports ready.',
+                    time: 'Just now'
+                });
+            }
+        }
+
+        if (this.workflowManager) {
+            const pendingDestemming = this.workflowManager.getPendingDestemming();
+            if (pendingDestemming.length) {
+                notifications.push({
+                    type: 'action',
+                    message: `${pendingDestemming.length} transport${pendingDestemming.length === 1 ? '' : 's'} awaiting destemming decisions.`,
+                    detail: 'Confirm press vs. direct fermentation to keep the intake line moving.',
+                    time: 'Today'
+                });
+            }
+
+            const overdueSettling = this.workflowManager.getActiveSettling().filter(workflow => {
+                const start = workflow.settling?.start;
+                if (!start) {
+                    return false;
+                }
+                const elapsed = (Date.now() - new Date(start).getTime()) / (1000 * 60 * 60);
+                return Number.isFinite(elapsed) && elapsed > 72;
+            });
+            if (overdueSettling.length) {
+                notifications.push({
+                    type: 'warning',
+                    message: `${overdueSettling.length} settling tank${overdueSettling.length === 1 ? '' : 's'} beyond 72 hours.`,
+                    detail: 'Rack or inoculate the clarified must to avoid oxidation risks.',
+                    time: 'Today'
+                });
+            }
+
+            const staleFermentations = this.workflowManager.getFermentationWithoutRecentReadings(30);
+            if (staleFermentations.length) {
+                notifications.push({
+                    type: 'warning',
+                    message: `Update readings for ${staleFermentations.length} harvest lot${staleFermentations.length === 1 ? '' : 's'}.`,
+                    detail: 'Last fermentation measurement recorded more than 30 hours ago.',
+                    time: 'Today'
+                });
+            }
+        }
+
+        if (!notifications.length) {
+            notifications.push({
+                type: 'success',
+                message: 'All systems up to date.',
+                detail: 'No pending actions. Great work!',
+                time: 'Just now'
+            });
+        }
+
+        return notifications.slice(0, 4);
+    }
+
+    updateNotificationBadge() {
+        const badge = document.querySelector('.btn-notifications .badge');
+        if (!badge) {
+            return;
+        }
+        const count = this.notifications.length;
+        badge.textContent = count > 99 ? '99+' : String(count);
+        badge.hidden = count === 0;
+    }
+
+    renderNotificationList() {
+        const list = document.getElementById('notificationList');
+        if (!list) {
+            return;
+        }
+        list.innerHTML = '';
+        this.notifications.forEach(notification => {
+            const item = document.createElement('li');
+            item.className = `notification-item ${notification.type ?? 'info'}`;
+            item.innerHTML = `
+                <p class="notification-message">${notification.message}</p>
+                ${notification.detail ? `<p class="notification-detail">${notification.detail}</p>` : ''}
+                <span class="notification-time">${notification.time ?? ''}</span>
+            `;
+            list.appendChild(item);
+        });
+    }
+
+    updateNotifications() {
+        this.notifications = this.buildNotificationData();
+        this.updateNotificationBadge();
+        if (this.notificationsOpen) {
+            this.renderNotificationList();
+        }
+    }
+
+    toggleNotifications(force) {
+        const panel = document.getElementById('notificationPanel');
+        const button = document.querySelector('.btn-notifications');
+        if (!panel || !button) {
+            return;
+        }
+        const nextState = typeof force === 'boolean' ? force : !this.notificationsOpen;
+        this.notificationsOpen = nextState;
+        panel.classList.toggle('show', nextState);
+        panel.setAttribute('aria-hidden', nextState ? 'false' : 'true');
+        button.setAttribute('aria-expanded', String(nextState));
+        if (nextState) {
+            this.renderNotificationList();
+        }
+    }
+
+    toggleCellarViewMode() {
+        this.cellar3DEnabled = !this.cellar3DEnabled;
+        this.renderCellarMap();
     }
 
     renderTemperatureChart() {
@@ -184,16 +1719,52 @@ class EnhancedDashboardApp {
 
     renderActivityFeed() {
         const container = document.getElementById('activityFeed');
-        if (!container || !this.batchManager) return;
+        if (!container) {
+            return;
+        }
         container.innerHTML = '';
-        const activities = this.batchManager.getAllBatches().flatMap(batch =>
-            (batch.history ?? []).map(event => ({ ...event, batch: batch.id }))
-        ).sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp)).slice(0, 10);
+
+        const batchActivities = this.batchManager
+            ? this.batchManager.getAllBatches().flatMap(batch =>
+                (batch.history ?? []).map(event => ({
+                    ...event,
+                    batchId: batch.id,
+                    source: batch.variety ? `${batch.variety} ${batch.vintage ?? ''}`.trim() : batch.id
+                }))
+            )
+            : [];
+
+        const workflowActivities = this.workflowManager
+            ? this.workflowManager.getWorkflows().flatMap(workflow =>
+                (workflow.history ?? []).map(event => ({
+                    ...event,
+                    workflowId: workflow.id,
+                    source: workflow.grapes?.variety || 'Harvest workflow'
+                }))
+            )
+            : [];
+
+        const activities = [...batchActivities, ...workflowActivities]
+            .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+            .slice(0, 12);
 
         activities.forEach(activity => {
             const item = document.createElement('div');
             item.className = 'activity-item';
-            item.innerHTML = `<strong>${activity.batch}</strong> - ${activity.type} on ${new Date(activity.timestamp).toLocaleString()}`;
+            if (activity.workflowId) {
+                const detail = activity.detail ? `<div class="small-note">${this.escapeHtml(activity.detail)}</div>` : '';
+                item.innerHTML = `
+                    <strong>${this.escapeHtml(activity.summary || activity.type || 'Workflow')}</strong>
+                    <div class="small-note">${this.escapeHtml(activity.source || '')} • ${this.formatDate(activity.timestamp)}</div>
+                    <div class="small-note">Workflow ${this.escapeHtml(activity.workflowId)}</div>
+                    ${detail}
+                `;
+            } else {
+                item.innerHTML = `
+                    <strong>${this.escapeHtml(activity.batchId || activity.batch || 'Batch')}</strong>
+                    <div class="small-note">${this.escapeHtml(activity.type || 'Update')} • ${this.formatDate(activity.timestamp)}</div>
+                `;
+            }
             container.appendChild(item);
         });
     }
@@ -403,5 +1974,12 @@ function closeModal() {
 }
 
 function toggleCellar3D() {
-    alert('3D view coming soon!');
+    enhancedApp.toggleCellarViewMode();
+}
+
+function toggleNotifications(event) {
+    if (event) {
+        event.stopPropagation();
+    }
+    enhancedApp.toggleNotifications();
 }

--- a/enhanced-app.js
+++ b/enhanced-app.js
@@ -32,6 +32,7 @@ class EnhancedDashboardApp {
         this.populateQuickAddSelector();
         this.bindNavigation();
         this.bindQuickAddForm();
+        this.bindHeaderActions();
         this.bindHarvestWorkflowForm();
         this.bindWorkflowActionHandlers();
         this.bindNotificationPanel();
@@ -67,6 +68,75 @@ class EnhancedDashboardApp {
             option.textContent = `${tank.id} (${tank.capacity} L)`;
             select.appendChild(option);
         });
+    }
+
+    bindHeaderActions() {
+        const quickAddButton = document.querySelector('[data-action="quick-add"]');
+        if (quickAddButton) {
+            quickAddButton.addEventListener('click', () => {
+                this.quickAdd();
+            });
+        }
+
+        const scanButton = document.querySelector('[data-action="open-scanner"]');
+        if (scanButton) {
+            scanButton.addEventListener('click', () => {
+                this.openScannerModal();
+            });
+        }
+
+        const toggleNotificationsButton = document.querySelector('[data-action="toggle-notifications"]');
+        if (toggleNotificationsButton) {
+            toggleNotificationsButton.addEventListener('click', (event) => {
+                event.stopPropagation();
+                this.toggleNotifications();
+            });
+        }
+
+        const closeNotificationsButton = document.querySelector('[data-action="close-notifications"]');
+        if (closeNotificationsButton) {
+            closeNotificationsButton.addEventListener('click', (event) => {
+                event.stopPropagation();
+                this.toggleNotifications(false);
+            });
+        }
+
+        const quickAddModal = document.getElementById('quickAddModal');
+        if (quickAddModal) {
+            quickAddModal.addEventListener('click', (event) => {
+                if (event.target === quickAddModal) {
+                    this.closeModal();
+                }
+            });
+        }
+
+        document.querySelectorAll('[data-action="close-modal"]').forEach(button => {
+            button.addEventListener('click', () => {
+                this.closeModal();
+            });
+        });
+
+        const scannerModal = document.getElementById('scannerModal');
+        if (scannerModal) {
+            scannerModal.addEventListener('click', (event) => {
+                if (event.target === scannerModal) {
+                    this.closeScanner();
+                }
+            });
+        }
+
+        document.querySelectorAll('[data-action="close-scanner"]').forEach(button => {
+            button.addEventListener('click', () => {
+                this.closeScanner();
+            });
+        });
+
+        const toggle3DButton = document.querySelector('[data-action="toggle-3d"]');
+        if (toggle3DButton) {
+            toggle3DButton.addEventListener('click', () => {
+                this.toggleCellarViewMode();
+            });
+        }
     }
 
     bindNavigation() {

--- a/enhanced-dashboard.html
+++ b/enhanced-dashboard.html
@@ -32,9 +32,9 @@
                     <button class="btn-search" type="button" aria-label="Search">🔍</button>
                 </div>
                 <div class="quick-actions">
-                    <button class="btn-scan" type="button" onclick="openBarcodeScanner()">📷 Scan</button>
-                    <button class="btn-add-reading" type="button" onclick="quickAddReading()">➕ Quick Add</button>
-                    <button class="btn-notifications" type="button" onclick="toggleNotifications(event)" aria-haspopup="true" aria-expanded="false">
+                    <button class="btn-scan" type="button" data-action="open-scanner">📷 Scan</button>
+                    <button class="btn-add-reading" type="button" data-action="quick-add">➕ Quick Add</button>
+                    <button class="btn-notifications" type="button" data-action="toggle-notifications" aria-haspopup="true" aria-expanded="false">
                         🔔 <span class="badge" aria-live="polite">0</span>
                     </button>
                 </div>
@@ -45,7 +45,7 @@
                 <div id="notificationPanel" class="notification-panel glass-card" aria-hidden="true">
                     <div class="panel-header">
                         <h3>Notifications</h3>
-                        <button type="button" class="panel-close" onclick="toggleNotifications(event)" aria-label="Close notifications">✕</button>
+                        <button type="button" class="panel-close" data-action="close-notifications" aria-label="Close notifications">✕</button>
                     </div>
                     <ul id="notificationList" class="notification-list"></ul>
                 </div>
@@ -97,7 +97,7 @@
                                 <option value="variety">By Variety</option>
                                 <option value="temperature">By Temperature</option>
                             </select>
-                            <button type="button" data-action="toggle-3d" onclick="toggleCellar3D()" aria-pressed="false">3D View</button>
+                            <button type="button" data-action="toggle-3d" aria-pressed="false">3D View</button>
                         </div>
                         <div id="cellarVisualization"></div>
                     </section>
@@ -276,7 +276,7 @@
                 <input type="number" id="quickPH" placeholder="pH" step="0.01">
                 <div class="modal-actions">
                     <button type="submit">Save</button>
-                    <button type="button" onclick="closeModal()">Cancel</button>
+                    <button type="button" data-action="close-modal">Cancel</button>
                 </div>
             </form>
         </div>
@@ -287,7 +287,7 @@
             <h2 id="scannerTitle" class="visually-hidden">Barcode scanner</h2>
             <video id="scannerVideo" autoplay muted playsinline></video>
             <div id="scanResult"></div>
-            <button type="button" onclick="closeScannerModal()">Close</button>
+            <button type="button" data-action="close-scanner">Close</button>
         </div>
     </div>
 

--- a/enhanced-dashboard.html
+++ b/enhanced-dashboard.html
@@ -15,124 +15,279 @@
                 <h2>VineTrack Pro</h2>
             </div>
             <ul class="nav-menu">
-                <li class="nav-item active"><span>Dashboard</span></li>
-                <li class="nav-item"><span>Tanks</span></li>
-                <li class="nav-item"><span>Batches</span></li>
-                <li class="nav-item"><span>Laboratory</span></li>
-                <li class="nav-item"><span>Production</span></li>
-                <li class="nav-item"><span>Analytics</span></li>
-                <li class="nav-item"><span>Settings</span></li>
+                <li><button type="button" class="nav-item active" data-view="dashboard" aria-controls="view-dashboard" aria-current="page">Dashboard</button></li>
+                <li><button type="button" class="nav-item" data-view="tanks" aria-controls="view-tanks">Tanks</button></li>
+                <li><button type="button" class="nav-item" data-view="batches" aria-controls="view-batches">Batches</button></li>
+                <li><button type="button" class="nav-item" data-view="laboratory" aria-controls="view-laboratory">Laboratory</button></li>
+                <li><button type="button" class="nav-item" data-view="production" aria-controls="view-production">Production</button></li>
+                <li><button type="button" class="nav-item" data-view="analytics" aria-controls="view-analytics">Analytics</button></li>
+                <li><button type="button" class="nav-item" data-view="settings" aria-controls="view-settings">Settings</button></li>
             </ul>
         </nav>
 
         <main class="main-content">
             <header class="dashboard-header glass-card">
                 <div class="search-bar">
-                    <input type="text" placeholder="Search batches, tanks, or wines...">
-                    <button class="btn-search">🔍</button>
+                    <input type="text" placeholder="Search batches, tanks, or wines..." aria-label="Search batches, tanks, or wines">
+                    <button class="btn-search" type="button" aria-label="Search">🔍</button>
                 </div>
                 <div class="quick-actions">
-                    <button class="btn-scan" onclick="openBarcodeScanner()">📷 Scan</button>
-                    <button class="btn-add-reading" onclick="quickAddReading()">➕ Quick Add</button>
-                    <button class="btn-notifications">🔔 <span class="badge">3</span></button>
+                    <button class="btn-scan" type="button" onclick="openBarcodeScanner()">📷 Scan</button>
+                    <button class="btn-add-reading" type="button" onclick="quickAddReading()">➕ Quick Add</button>
+                    <button class="btn-notifications" type="button" onclick="toggleNotifications(event)" aria-haspopup="true" aria-expanded="false">
+                        🔔 <span class="badge" aria-live="polite">0</span>
+                    </button>
                 </div>
                 <div class="user-profile">
                     <img src="user-avatar.jpg" alt="User" width="48" height="48">
                     <span>Winemaker</span>
                 </div>
+                <div id="notificationPanel" class="notification-panel glass-card" aria-hidden="true">
+                    <div class="panel-header">
+                        <h3>Notifications</h3>
+                        <button type="button" class="panel-close" onclick="toggleNotifications(event)" aria-label="Close notifications">✕</button>
+                    </div>
+                    <ul id="notificationList" class="notification-list"></ul>
+                </div>
             </header>
 
-            <div class="kpi-grid">
-                <div class="kpi-card glass-card">
-                    <div class="kpi-icon">🍇</div>
-                    <div class="kpi-content">
-                        <h3>Active Fermentations</h3>
-                        <p class="kpi-value" id="kpiFermentations">0</p>
-                        <span class="kpi-trend positive" id="kpiFermentationTrend"></span>
+            <div class="view-container">
+                <section class="view-panel active" data-view="dashboard" id="view-dashboard" aria-label="Dashboard overview" aria-hidden="false">
+                    <div class="kpi-grid">
+                        <div class="kpi-card glass-card">
+                            <div class="kpi-icon">🍇</div>
+                            <div class="kpi-content">
+                                <h3>Active Fermentations</h3>
+                                <p class="kpi-value" id="kpiFermentations">0</p>
+                                <span class="kpi-trend positive" id="kpiFermentationTrend"></span>
+                            </div>
+                        </div>
+                        <div class="kpi-card glass-card">
+                            <div class="kpi-icon">🏺</div>
+                            <div class="kpi-content">
+                                <h3>Total Volume</h3>
+                                <p class="kpi-value" id="kpiVolume">0 L</p>
+                                <span class="kpi-trend" id="kpiCapacity"></span>
+                            </div>
+                        </div>
+                        <div class="kpi-card glass-card">
+                            <div class="kpi-icon">⚗️</div>
+                            <div class="kpi-content">
+                                <h3>Lab Samples Today</h3>
+                                <p class="kpi-value" id="kpiLabSamples">0</p>
+                                <span class="kpi-trend" id="kpiLabPending"></span>
+                            </div>
+                        </div>
+                        <div class="kpi-card glass-card">
+                            <div class="kpi-icon">📊</div>
+                            <div class="kpi-content">
+                                <h3>Quality Score</h3>
+                                <p class="kpi-value" id="kpiQuality">0</p>
+                                <span class="kpi-trend positive" id="kpiQualityTrend"></span>
+                            </div>
+                        </div>
                     </div>
-                </div>
-                <div class="kpi-card glass-card">
-                    <div class="kpi-icon">🏺</div>
-                    <div class="kpi-content">
-                        <h3>Total Volume</h3>
-                        <p class="kpi-value" id="kpiVolume">0 L</p>
-                        <span class="kpi-trend" id="kpiCapacity"></span>
+
+                    <section class="cellar-map glass-card">
+                        <h2>Cellar Overview</h2>
+                        <div class="cellar-controls">
+                            <label for="cellarView" class="visually-hidden">Cellar view mode</label>
+                            <select id="cellarView">
+                                <option value="status">By Status</option>
+                                <option value="variety">By Variety</option>
+                                <option value="temperature">By Temperature</option>
+                            </select>
+                            <button type="button" data-action="toggle-3d" onclick="toggleCellar3D()" aria-pressed="false">3D View</button>
+                        </div>
+                        <div id="cellarVisualization"></div>
+                    </section>
+
+                    <section class="monitoring-grid">
+                        <div class="monitor-card glass-card">
+                            <h3>Temperature Monitoring</h3>
+                            <canvas id="tempMonitorChart" aria-label="Tank temperature trends" role="img"></canvas>
+                        </div>
+                        <div class="monitor-card glass-card">
+                            <h3>Fermentation Progress</h3>
+                            <div id="fermentationProgress"></div>
+                        </div>
+                        <div class="monitor-card glass-card">
+                            <h3>Recent Activities</h3>
+                            <div class="activity-feed" id="activityFeed"></div>
+                        </div>
+                    </section>
+
+                    <section class="batch-timeline-section glass-card">
+                        <h2>Production Timeline</h2>
+                        <div class="batch-timeline" id="productionTimeline">
+                            <div class="timeline-line"></div>
+                        </div>
+                    </section>
+                </section>
+
+                <section class="view-panel" data-view="tanks" id="view-tanks" aria-label="Tank overview" aria-hidden="true">
+                    <div class="panel-header">
+                        <h2>Tank Overview</h2>
+                        <p>Monitor cellar capacity, assignments, and the freshness of your readings.</p>
                     </div>
-                </div>
-                <div class="kpi-card glass-card">
-                    <div class="kpi-icon">⚗️</div>
-                    <div class="kpi-content">
-                        <h3>Lab Samples Today</h3>
-                        <p class="kpi-value" id="kpiLabSamples">0</p>
-                        <span class="kpi-trend" id="kpiLabPending"></span>
+                    <div id="tankOverviewList" class="list-grid"></div>
+                    <div id="tanksEmptyState" class="empty-state glass-card" hidden>
+                        <h3>No tanks configured yet</h3>
+                        <p>Import your cellar layout or use Quick Add to start tracking fermentation vessels.</p>
                     </div>
-                </div>
-                <div class="kpi-card glass-card">
-                    <div class="kpi-icon">📊</div>
-                    <div class="kpi-content">
-                        <h3>Quality Score</h3>
-                        <p class="kpi-value" id="kpiQuality">0</p>
-                        <span class="kpi-trend positive" id="kpiQualityTrend"></span>
+                </section>
+
+                <section class="view-panel" data-view="batches" id="view-batches" aria-label="Batch management" aria-hidden="true">
+                    <div class="panel-header">
+                        <h2>Batch Management</h2>
+                        <p>Track varietals, volumes, and statuses across your cellar.</p>
                     </div>
-                </div>
+                    <div id="batchOverviewList" class="list-grid"></div>
+                    <div id="batchesEmptyState" class="empty-state glass-card" hidden>
+                        <h3>No batches recorded</h3>
+                        <p>Create a batch from a tank to begin capturing fermentation history.</p>
+                    </div>
+                </section>
+
+                <section class="view-panel" data-view="laboratory" id="view-laboratory" aria-label="Laboratory results" aria-hidden="true">
+                    <div class="panel-header">
+                        <h2>Laboratory Results</h2>
+                        <p>Review the latest chemistry and quality metrics from your lab team.</p>
+                    </div>
+                    <div id="labResultsList" class="list-grid"></div>
+                    <div id="labEmptyState" class="empty-state glass-card" hidden>
+                        <h3>No lab results yet</h3>
+                        <p>When you add analyses to a batch, the most recent measurements will appear here.</p>
+                    </div>
+                </section>
+
+                <section class="view-panel" data-view="production" id="view-production" aria-label="Production schedule" aria-hidden="true">
+                    <div class="panel-header">
+                        <h2>Production Planning</h2>
+                        <p>Coordinate harvest, fermentation, aging, and bottling activities.</p>
+                    </div>
+                    <div id="productionSchedule" class="timeline-grid"></div>
+                    <div id="productionEmptyState" class="empty-state glass-card" hidden>
+                        <h3>No production plan available</h3>
+                        <p>Set your vintage to generate a timeline with resource utilization insights.</p>
+                    </div>
+                    <section class="workflow-section" aria-label="Harvest workflow">
+                        <article class="glass-card workflow-intake-card">
+                            <h3>Log grape transport</h3>
+                            <form id="harvestIntakeForm" novalidate>
+                                <div class="workflow-form-grid">
+                                    <div class="form-field">
+                                        <label for="intakeArrival">Arrival time</label>
+                                        <input type="datetime-local" id="intakeArrival" name="arrivalTime" required>
+                                    </div>
+                                    <div class="form-field">
+                                        <label for="intakeVineyard">Vineyard</label>
+                                        <input type="text" id="intakeVineyard" name="vineyard" placeholder="Vineyard name">
+                                    </div>
+                                    <div class="form-field">
+                                        <label for="intakeBlock">Block</label>
+                                        <input type="text" id="intakeBlock" name="block" placeholder="Block / parcel">
+                                    </div>
+                                    <div class="form-field">
+                                        <label for="intakeVariety">Variety</label>
+                                        <input type="text" id="intakeVariety" name="variety" placeholder="e.g. Fetească Albă" required>
+                                    </div>
+                                    <div class="form-field">
+                                        <label for="intakeVehicle">Transport</label>
+                                        <select id="intakeVehicle" name="vehicleType">
+                                            <option value="tractor-trailer">Tractor trailer with crates</option>
+                                            <option value="fiat-ducato">Coachbuilt Fiat Ducato</option>
+                                            <option value="other">Other transport</option>
+                                        </select>
+                                    </div>
+                                    <div class="form-field">
+                                        <label for="intakeCrates">Crates</label>
+                                        <input type="number" id="intakeCrates" name="crateCount" min="1" step="1" placeholder="Number of crates" required>
+                                    </div>
+                                    <div class="form-field">
+                                        <label for="intakeWeight">Average crate weight (kg)</label>
+                                        <input type="number" id="intakeWeight" name="crateWeight" min="10" max="25" step="0.1" placeholder="14-19 kg" required>
+                                    </div>
+                                </div>
+                                <fieldset class="form-fieldset">
+                                    <legend>Processing route</legend>
+                                    <div class="fieldset-options">
+                                        <div class="option">
+                                            <input type="radio" id="routePress" name="route" value="press" checked>
+                                            <label for="routePress">Destem &amp; press for settling</label>
+                                        </div>
+                                        <div class="option">
+                                            <input type="radio" id="routeTank" name="route" value="tank">
+                                            <label for="routeTank">Destem &amp; send to fermentation tank</label>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                                <div class="form-field">
+                                    <label for="intakeNotes">Notes</label>
+                                    <textarea id="intakeNotes" name="notes" rows="2" placeholder="Observations, vineyard maturity, etc."></textarea>
+                                </div>
+                                <button type="submit" class="btn-primary">Add transport</button>
+                            </form>
+                        </article>
+                        <div class="workflow-board">
+                            <div id="harvestWorkflowEmptyState" class="empty-state glass-card" hidden>
+                                <h3>No harvest lots in progress</h3>
+                                <p>Log a transport to track destemming, pressing, settling, and fermentation.</p>
+                            </div>
+                            <div id="harvestWorkflowList" class="workflow-list" aria-live="polite"></div>
+                        </div>
+                    </section>
+                </section>
+
+                <section class="view-panel" data-view="analytics" id="view-analytics" aria-label="Analytics" aria-hidden="true">
+                    <div class="panel-header">
+                        <h2>AI Analytics</h2>
+                        <p>Forecast fermentation completion dates and identify potential risks.</p>
+                    </div>
+                    <div id="analyticsSummary" class="list-grid analytics-grid"></div>
+                    <div id="analyticsEmptyState" class="empty-state glass-card" hidden>
+                        <h3>Analytics will appear here</h3>
+                        <p>Add readings to your tanks to unlock AI-powered fermentation forecasts.</p>
+                    </div>
+                </section>
+
+                <section class="view-panel" data-view="settings" id="view-settings" aria-label="System settings" aria-hidden="true">
+                    <div class="panel-header">
+                        <h2>System Settings</h2>
+                        <p>Review connectivity, integrations, and AI readiness for your winery.</p>
+                    </div>
+                    <div id="settingsPanel" class="settings-grid"></div>
+                </section>
             </div>
-
-            <section class="cellar-map glass-card">
-                <h2>Cellar Overview</h2>
-                <div class="cellar-controls">
-                    <select id="cellarView">
-                        <option value="status">By Status</option>
-                        <option value="variety">By Variety</option>
-                        <option value="temperature">By Temperature</option>
-                    </select>
-                    <button onclick="toggleCellar3D()">3D View</button>
-                </div>
-                <div id="cellarVisualization"></div>
-            </section>
-
-            <section class="monitoring-grid">
-                <div class="monitor-card glass-card">
-                    <h3>Temperature Monitoring</h3>
-                    <canvas id="tempMonitorChart"></canvas>
-                </div>
-                <div class="monitor-card glass-card">
-                    <h3>Fermentation Progress</h3>
-                    <div id="fermentationProgress"></div>
-                </div>
-                <div class="monitor-card glass-card">
-                    <h3>Recent Activities</h3>
-                    <div class="activity-feed" id="activityFeed"></div>
-                </div>
-            </section>
-
-            <section class="batch-timeline-section glass-card">
-                <h2>Production Timeline</h2>
-                <div class="batch-timeline" id="productionTimeline">
-                    <div class="timeline-line"></div>
-                </div>
-            </section>
         </main>
     </div>
 
-    <div id="quickAddModal" class="modal">
+    <div id="quickAddModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="quickAddTitle">
         <div class="modal-content glass-card">
-            <h2>Quick Reading</h2>
+            <h2 id="quickAddTitle">Quick Reading</h2>
             <form id="quickReadingForm">
+                <label for="quickTank" class="visually-hidden">Tank</label>
                 <select id="quickTank" required></select>
+                <label for="quickTemp" class="visually-hidden">Temperature</label>
                 <input type="number" id="quickTemp" placeholder="Temperature (°C)" step="0.1">
+                <label for="quickSugar" class="visually-hidden">Sugar</label>
                 <input type="number" id="quickSugar" placeholder="Sugar (Baumé)" step="0.1">
+                <label for="quickPH" class="visually-hidden">pH</label>
                 <input type="number" id="quickPH" placeholder="pH" step="0.01">
-                <button type="submit">Save</button>
-                <button type="button" onclick="closeModal()">Cancel</button>
+                <div class="modal-actions">
+                    <button type="submit">Save</button>
+                    <button type="button" onclick="closeModal()">Cancel</button>
+                </div>
             </form>
         </div>
     </div>
 
-    <div id="scannerModal" class="modal">
+    <div id="scannerModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="scannerTitle">
         <div class="modal-content">
+            <h2 id="scannerTitle" class="visually-hidden">Barcode scanner</h2>
             <video id="scannerVideo" autoplay muted playsinline></video>
             <div id="scanResult"></div>
-            <button onclick="closeScannerModal()">Close</button>
+            <button type="button" onclick="closeScannerModal()">Close</button>
         </div>
     </div>
 
@@ -145,6 +300,7 @@
     <script src="aiAnalytics.js"></script>
     <script src="apiIntegration.js"></script>
     <script src="pwa.js"></script>
+    <script src="workflowManager.js"></script>
     <script src="enhanced-app.js"></script>
 </body>
 </html>

--- a/enhanced-styles.css
+++ b/enhanced-styles.css
@@ -48,18 +48,33 @@
     gap: 1rem;
 }
 
-.nav-item {
+.nav-menu li {
+    list-style: none;
+}
+
+.nav-menu .nav-item {
     display: flex;
     align-items: center;
     gap: 0.75rem;
     padding: 0.75rem 1rem;
     border-radius: 12px;
     cursor: pointer;
-    transition: background 0.3s;
+    transition: background 0.3s, transform 0.2s;
+    background: transparent;
+    border: none;
+    color: inherit;
+    font: inherit;
+    width: 100%;
+    text-align: left;
 }
 
-.nav-item.active,
-.nav-item:hover {
+.nav-menu .nav-item:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.6);
+    outline-offset: 2px;
+}
+
+.nav-menu .nav-item.active,
+.nav-menu .nav-item:hover {
     background: rgba(255, 255, 255, 0.2);
 }
 
@@ -75,6 +90,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
+    position: relative;
 }
 
 .search-bar {
@@ -260,6 +276,418 @@
     overflow-y: auto;
 }
 
+.quick-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.quick-actions button {
+    background: rgba(255, 255, 255, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    color: inherit;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    font-weight: 600;
+    transition: transform 0.2s ease, background 0.3s ease;
+}
+
+.quick-actions button:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.3);
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.5rem;
+    padding: 0 0.4rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.25);
+    font-size: 0.75rem;
+    margin-left: 0.4rem;
+    font-weight: 600;
+}
+
+.btn-notifications[aria-expanded="true"] .badge {
+    background: rgba(255, 255, 255, 0.5);
+}
+
+.view-container {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    position: relative;
+}
+
+.view-panel {
+    display: none;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.view-panel.active {
+    display: flex;
+}
+
+.panel-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.panel-header h2 {
+    font-size: 1.8rem;
+    font-weight: 600;
+}
+
+.panel-header p {
+    color: rgba(255, 255, 255, 0.85);
+    max-width: 620px;
+}
+
+.list-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.analytics-grid {
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+.timeline-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.settings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.empty-state {
+    text-align: center;
+    border: 1px dashed rgba(255, 255, 255, 0.35);
+    padding: 2rem;
+}
+
+.empty-state h3 {
+    font-size: 1.4rem;
+    margin-bottom: 0.5rem;
+}
+
+.empty-state p {
+    color: rgba(255, 255, 255, 0.75);
+    margin: 0;
+}
+
+.tank-overview-card header,
+.batch-overview-card header,
+.analytics-card header,
+.settings-card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.metric-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.75rem;
+    margin: 1rem 0;
+}
+
+.metric-list div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.metric-list dt {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.7;
+}
+
+.metric-list dd {
+    margin: 0;
+    font-weight: 600;
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.18);
+}
+
+.status-pill.status-active {
+    background: rgba(46, 125, 50, 0.35);
+}
+
+.status-pill.status-success {
+    background: rgba(120, 200, 120, 0.35);
+}
+
+.status-pill.status-idle {
+    background: rgba(255, 255, 255, 0.18);
+}
+
+.status-pill.status-warning {
+    background: rgba(255, 193, 7, 0.35);
+}
+
+.status-pill.status-planned {
+    background: rgba(114, 47, 55, 0.35);
+}
+
+.progress {
+    width: 100%;
+    height: 8px;
+    background: rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+    overflow: hidden;
+    margin-top: 0.75rem;
+}
+
+.progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, var(--secondary), rgba(255, 255, 255, 0.7));
+}
+
+.progress-label {
+    font-size: 0.8rem;
+    opacity: 0.8;
+    margin-top: 0.25rem;
+}
+
+.notification-panel {
+    position: absolute;
+    top: calc(100% + 1rem);
+    right: 0;
+    width: min(320px, 80vw);
+    display: none;
+    z-index: 20;
+    padding: 1.25rem;
+}
+
+.notification-panel.show {
+    display: block;
+}
+
+.notification-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.notification-item {
+    padding: 0.75rem 0.9rem;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.notification-item.info {
+    border-left: 3px solid rgba(120, 144, 255, 0.6);
+}
+
+.notification-item.warning {
+    border-left: 3px solid rgba(255, 202, 40, 0.7);
+}
+
+.notification-item.success {
+    border-left: 3px solid rgba(46, 125, 50, 0.6);
+}
+
+.notification-item.action {
+    border-left: 3px solid rgba(255, 255, 255, 0.6);
+}
+
+.notification-message {
+    font-weight: 600;
+}
+
+.notification-detail {
+    font-size: 0.85rem;
+    opacity: 0.8;
+}
+
+.notification-time {
+    font-size: 0.75rem;
+    opacity: 0.6;
+}
+
+.panel-close {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+.settings-card ul,
+.production-card ul,
+.suggestions-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.production-card footer,
+.settings-card footer {
+    margin-top: 1rem;
+    font-size: 0.8rem;
+    opacity: 0.7;
+}
+
+.modal-actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+}
+
+.modal-actions button {
+    flex: 1;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    border: none;
+    font-weight: 600;
+    cursor: pointer;
+    background: rgba(255, 255, 255, 0.2);
+    color: inherit;
+}
+
+.modal-actions button[type="submit"] {
+    background: linear-gradient(120deg, var(--secondary), rgba(255, 255, 255, 0.6));
+    color: var(--dark);
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
+.cellar-controls select,
+.cellar-controls button {
+    background: rgba(255, 255, 255, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 999px;
+    padding: 0.45rem 1rem;
+    color: inherit;
+}
+
+.cellar-controls button[aria-pressed="true"] {
+    background: rgba(255, 255, 255, 0.35);
+}
+
+.cellar-3d {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem;
+    perspective: 1100px;
+}
+
+.cellar-3d__tank {
+    position: relative;
+    padding: 1.5rem;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.12);
+    min-height: 200px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    overflow: hidden;
+}
+
+.cellar-3d__tank::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.15));
+    transform: rotateX(55deg);
+    transform-origin: top;
+    opacity: 0.35;
+    pointer-events: none;
+}
+
+.cellar-3d__tank h3 {
+    margin-bottom: 0.5rem;
+}
+
+.cellar-3d__meta {
+    font-size: 0.85rem;
+    opacity: 0.8;
+}
+
+.cellar-3d__level {
+    position: relative;
+    height: 120px;
+    border-radius: 14px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+    overflow: hidden;
+}
+
+.cellar-3d__level-fill {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: linear-gradient(180deg, rgba(114, 47, 55, 0.8), rgba(114, 47, 55, 0.4));
+}
+
+.production-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.analytics-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.analytics-card footer {
+    font-size: 0.85rem;
+    opacity: 0.75;
+}
+
+.settings-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.settings-card .status-pill {
+    align-self: flex-start;
+}
+
 .modal {
     display: none;
     position: fixed;
@@ -323,6 +751,335 @@
     background: rgba(255, 255, 255, 0.18);
 }
 
+.workflow-section {
+    margin-top: 2rem;
+    display: grid;
+    grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+    gap: 2rem;
+    align-items: flex-start;
+}
+
+.workflow-intake-card h3 {
+    margin-bottom: 1rem;
+}
+
+.workflow-form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.form-field label,
+.form-fieldset legend {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea,
+.form-fieldset input[type="radio"] + label {
+    font-family: inherit;
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.08);
+    color: inherit;
+    padding: 0.65rem 0.75rem;
+    min-height: 44px;
+}
+
+.form-field textarea {
+    min-height: 80px;
+    resize: vertical;
+}
+
+.form-fieldset {
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 16px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1.5rem;
+}
+
+.fieldset-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem 1.5rem;
+    margin-top: 0.5rem;
+}
+
+.fieldset-options .option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+}
+
+.btn-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    padding: 0.75rem 1.5rem;
+    border-radius: 999px;
+    border: none;
+    background: linear-gradient(135deg, var(--secondary), rgba(255, 255, 255, 0.75));
+    color: var(--dark);
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
+}
+
+.workflow-board {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.workflow-list {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.workflow-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.workflow-card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+}
+
+.workflow-card header h3 {
+    margin: 0;
+}
+
+.workflow-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 0.75rem 1.5rem;
+}
+
+.workflow-meta dt {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.65;
+}
+
+.workflow-meta dd {
+    margin: 0;
+    font-weight: 600;
+}
+
+.workflow-progress {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.workflow-progress li {
+    padding: 0.5rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    font-size: 0.85rem;
+}
+
+.workflow-progress li.completed {
+    background: rgba(46, 125, 50, 0.3);
+}
+
+.workflow-progress li.in-progress {
+    background: rgba(255, 213, 79, 0.35);
+    color: var(--dark);
+}
+
+.workflow-actions {
+    display: grid;
+    gap: 1rem;
+}
+
+.workflow-action-form {
+    display: grid;
+    gap: 0.75rem;
+    padding: 1rem;
+    border-radius: 16px;
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.workflow-action-form h4 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.workflow-action-form .form-row {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.workflow-action-form button[type="submit"] {
+    justify-self: flex-start;
+}
+
+.workflow-subsection {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.workflow-subsection h4 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.workflow-additions,
+.workflow-history {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.workflow-additions li,
+.workflow-history li {
+    padding: 0.5rem 0.75rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.08);
+    font-size: 0.9rem;
+}
+
+.workflow-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+
+.workflow-table th,
+.workflow-table td {
+    padding: 0.5rem 0.65rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    text-align: left;
+}
+
+.workflow-table th {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.65;
+}
+
+.workflow-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.workflow-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.4rem 0.7rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.15);
+    font-size: 0.8rem;
+}
+
+.workflow-alert {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(183, 28, 28, 0.28);
+    padding: 0.5rem 0.9rem;
+    border-radius: 12px;
+    font-size: 0.85rem;
+}
+
+.workflow-status-completed {
+    background: rgba(46, 125, 50, 0.3);
+}
+
+.workflow-status-warning {
+    background: rgba(255, 213, 79, 0.35);
+    color: var(--dark);
+}
+
+.workflow-status-pending {
+    background: rgba(255, 255, 255, 0.18);
+}
+
+.workflow-card footer {
+    font-size: 0.85rem;
+    opacity: 0.75;
+}
+
+.workflow-card footer strong {
+    color: rgba(255, 255, 255, 0.95);
+}
+
+.workflow-inline-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 0.75rem;
+}
+
+.workflow-inline-group label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.workflow-inline-group input,
+.workflow-inline-group select {
+    min-height: 40px;
+}
+
+.workflow-card .small-note {
+    font-size: 0.8rem;
+    opacity: 0.7;
+}
+
+.workflow-card details {
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 12px;
+    padding: 0.75rem 1rem;
+}
+
+.workflow-card summary {
+    cursor: pointer;
+}
+
+.workflow-card details[open] {
+    border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.workflow-card details p {
+    margin: 0.5rem 0 0;
+}
+
 @media (max-width: 1024px) {
     .dashboard-container {
         flex-direction: column;
@@ -331,5 +1088,13 @@
     .sidebar {
         width: 100%;
         margin-right: 0;
+    }
+
+    .workflow-section {
+        grid-template-columns: 1fr;
+    }
+
+    .workflow-form-grid {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
     }
 }

--- a/index.html
+++ b/index.html
@@ -3,273 +3,415 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Winery Fermentation Tracker</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="enhanced-mobile.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+    <title>VineTrack Pro — Professional Winemaking Management</title>
+    <link rel="icon" type="image/svg+xml" href="assets/images/logo.svg">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap">
+    <link rel="stylesheet" href="assets/css/landing.css">
 </head>
 <body>
-    <header>
-        <h1>Fermentation Log</h1>
-        <button id="toggleOverviewBtn">Show Overview</button>
+    <header class="hero-header">
+        <div class="header-container">
+            <div class="logo-container">
+                <img src="assets/images/logo.svg" alt="VineTrack Pro" class="logo">
+                <span class="logo-title">VineTrack Pro</span>
+            </div>
+            <nav class="main-nav" aria-label="Primary">
+                <a href="#features" class="nav-link">Features</a>
+                <a href="#how-it-works" class="nav-link">How It Works</a>
+                <a href="#testimonials" class="nav-link">Testimonials</a>
+                <a href="#pricing" class="nav-link">Pricing</a>
+                <a href="#contact" class="nav-link">Contact</a>
+                <a href="enhanced-dashboard.html" class="btn-primary">Launch App</a>
+            </nav>
+        </div>
     </header>
-    <main>
-        <section class="overview hidden">
-            <h2>Overview</h2>
-            <table id="overviewTable">
-                <thead>
-                    <tr>
-                        <th>Tank</th>
-                        <th>Date & Time</th>
-                        <th>Temp (°C)</th>
-                        <th>Sugar (Baumé)</th>
-                        <th>Specific Gravity</th>
-                        <th>pH</th>
-                        <th>TA (g/L)</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody id="overviewTableBody"></tbody>
-            </table>
-        </section>
-        <section class="quick-insights">
-            <h2>Quick Insights</h2>
-            <div id="insightsContainer" class="insights-grid">
-                <!-- Insights will be dynamically generated here -->
+
+    <section class="hero-section" id="top">
+        <div class="hero-content">
+            <h1>Professional Fermentation Tracking &amp; Winemaking Management</h1>
+            <p class="hero-subtitle">The only OIV-compliant, AI-enhanced platform that unifies cellar operations, compliance, and predictive analytics for modern wineries.</p>
+            <div class="hero-cta">
+                <a href="enhanced-dashboard.html" class="btn-primary btn-large">Start Free Trial</a>
+                <a href="#demo" class="btn-secondary btn-large">Watch Demo</a>
             </div>
-        </section>
-
-        <section class="tank-info">
-            <h2>Select Tank</h2>
-            <div class="info-inputs">
-                <label for="tankSelect">Tank:</label>
-                <select id="tankSelect"></select>
-
-                <label for="grapeVarietyInput">Variety:</label>
-                <input type="text" id="grapeVarietyInput" placeholder="e.g., Chardonnay">
-
-                <p id="tankDetails"></p>
-            </div>
-        </section>
-
-        <section class="data-entry">
-            <h2>New Reading / Addition</h2>
-            <form id="readingForm">
-                <div class="form-grid">
-                    <div class="form-group">
-                        <label for="timestamp">Date & Time</label>
-                       <input type="text" id="timestamp" required>
+            <div class="hero-visual" aria-hidden="true">
+                <div class="dashboard-preview">
+                    <div class="dashboard-header">
+                        <span class="status-chip success">Healthy Fermentation</span>
+                        <span class="status-chip warning">SO₂ Alert</span>
                     </div>
-                    <div class="form-group">
-                        <label for="temperature">Temperature (°C)</label>
-                        <input type="number" id="temperature" step="0.1" placeholder="e.g., 15.5">
-                    </div>
-                    <div class="form-group">
-                        <label for="brix">Refractometer (°Bx)</label>
-                        <input type="number" id="brix" step="0.1" placeholder="e.g., 20.5">
-                    </div>
-                    <div class="form-group">
-                        <label for="sugar">Sugar (Baumé)</label>
-                        <input type="number" id="sugar" step="0.1" placeholder="e.g., 12.5">
-                        <input type="number" id="sugarGL" placeholder="g/L">
-                    </div>
-                    <div class="form-group">
-                        <label for="sg">Specific Gravity</label>
-                        <input type="number" id="sg" step="0.001" placeholder="e.g., 1.020">
-                    </div>
-                    <div class="form-group">
-                        <label for="ph">pH</label>
-                        <input type="number" id="ph" step="0.01" placeholder="e.g., 3.25">
-                    </div>
-                    <div class="form-group">
-                        <label for="ta">Total Acidity (g/L)</label>
-                        <input type="number" id="ta" step="0.1" placeholder="e.g., 6.8">
-                    </div>
-                    <div class="form-group">
-                        <label for="volume">Volume (L)</label>
-                        <input type="number" id="volume" step="0.1" placeholder="e.g., 1000">
-                    </div>
-                    <div class="form-group full-width">
-                        <label for="notes">Additions & Notes</label>
-                        <textarea id="notes" rows="3" placeholder="e.g., Added 50g of Nutrient X"></textarea>
+                    <div class="dashboard-body">
+                        <div class="metric-card">
+                            <p class="metric-label">Avg. Temp</p>
+                            <p class="metric-value">18.6°C</p>
+                        </div>
+                        <div class="metric-card">
+                            <p class="metric-label">Baumé Drop</p>
+                            <p class="metric-value">-0.4</p>
+                        </div>
+                        <div class="metric-card">
+                            <p class="metric-label">Completion Forecast</p>
+                            <p class="metric-value">3.5 days</p>
+                        </div>
+                        <div class="sparkline"></div>
                     </div>
                 </div>
-                <button type="submit">Save Reading</button>
-            </form>
-        </section>
-
-        <section class="calculator">
-            <h2>Additive Calculator</h2>
-            <p>Enter the batch volume and dosage rates. For g/hL rates, amount&nbsp;=&nbsp;volume&nbsp;×&nbsp;rate&nbsp;/&nbsp;100. For SO₂ (KMS) in mg/L, amount&nbsp;=&nbsp;volume&nbsp;×&nbsp;rate&nbsp;/&nbsp;1000.</p>
-            <div class="form-group">
-                <label for="calcVolume">Volume (L)</label>
-                <input type="number" id="calcVolume" step="0.1" placeholder="e.g., 1000">
             </div>
-            <table class="calc-table">
-                <thead>
-                    <tr>
-                        <th>Additive</th>
-                        <th>Dosage Rate</th>
-                        <th>Amount (g)</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Nutrients (g/hL)</td>
-                        <td><input type="number" id="nutrientRate" step="0.01" placeholder="e.g., 20"></td>
-                        <td><span id="nutrientAmount"></span></td>
-                        <td><button type="button" id="nutrientSave">Save to Log</button></td>
-                    </tr>
-                    <tr>
-                        <td>Enzymes (g/hL)</td>
-                        <td><input type="number" id="enzymeRate" step="0.01" placeholder="e.g., 2"></td>
-                        <td><span id="enzymeAmount"></span></td>
-                        <td><button type="button" id="enzymeSave">Save to Log</button></td>
-                    </tr>
-                    <tr>
-                        <td>SO₂ (KMS) (mg/L)</td>
-                        <td><input type="number" id="kmsRate" step="1" placeholder="e.g., 50"></td>
-                        <td><span id="kmsAmount"></span></td>
-                        <td><button type="button" id="kmsSave">Save to Log</button></td>
-                    </tr>
-                    <tr>
-                        <td>Bentonite</td>
-                        <td>
-                            <input type="number" id="bentoniteRate" step="0.01" placeholder="e.g., 1">
-                            <button type="button" id="bentoniteUnitBtn">g/L</button>
-                        </td>
-                        <td><span id="bentoniteAmount"></span></td>
-                        <td><button type="button" id="bentoniteSave">Save to Log</button></td>
-                    </tr>
-                    <tr>
-                        <td>Tannins (g/hL)</td>
-                        <td><input type="number" id="tanninRate" step="0.01" placeholder="e.g., 5"></td>
-                        <td><span id="tanninAmount"></span></td>
-                        <td><button type="button" id="tanninSave">Save to Log</button></td>
-                    </tr>
-                </tbody>
-            </table>
-        </section>
+        </div>
+    </section>
 
-        <section class="acid-calculator">
-            <h2>pH Adjustment Calculator</h2>
-            <div class="form-group">
-                <label for="currentPH">Current pH</label>
-                <input type="number" id="currentPH" step="0.01" placeholder="e.g., 3.8">
+    <section id="features" class="features-section">
+        <div class="section-header">
+            <h2>Designed for Professional Winemaking</h2>
+            <p>Expert-built toolset that keeps cellar teams aligned, compliant, and proactive.</p>
+        </div>
+        <div class="features-grid">
+            <article class="feature-card">
+                <div class="feature-icon" aria-hidden="true">📊</div>
+                <h3>Real-time Fermentation Monitoring</h3>
+                <p>Track temperature, sugar, pH, and kinetics with automated anomaly detection and predictive forecasts.</p>
+                <ul class="feature-list">
+                    <li>Customisable alerts</li>
+                    <li>AI completion forecasting</li>
+                    <li>Historical trend analysis</li>
+                </ul>
+            </article>
+            <article class="feature-card">
+                <div class="feature-icon" aria-hidden="true">🔍</div>
+                <h3>Full Traceability</h3>
+                <p>Document every movement from vineyard to bottle with audit-ready logs and chain-of-custody reports.</p>
+                <ul class="feature-list">
+                    <li>Wine genealogy tracking</li>
+                    <li>Automatic compliance reports</li>
+                    <li>QR / barcode integration</li>
+                </ul>
+            </article>
+            <article class="feature-card">
+                <div class="feature-icon" aria-hidden="true">🧪</div>
+                <h3>Laboratory Integration</h3>
+                <p>Sync lab assays, flag stability risks, and calculate SO₂ or additions without leaving the dashboard.</p>
+                <ul class="feature-list">
+                    <li>Automated quality scoring</li>
+                    <li>Stability assessment tools</li>
+                    <li>Centralised lab history</li>
+                </ul>
+            </article>
+            <article class="feature-card">
+                <div class="feature-icon" aria-hidden="true">📈</div>
+                <h3>Business Intelligence</h3>
+                <p>Understand production costs, plan bottlings, and model pricing with data-driven insights.</p>
+                <ul class="feature-list">
+                    <li>Profitability tracking</li>
+                    <li>Production planning</li>
+                    <li>Demand forecasting</li>
+                </ul>
+            </article>
+        </div>
+    </section>
+
+    <section id="how-it-works" class="how-it-works">
+        <div class="section-header">
+            <h2>How VineTrack Pro Works</h2>
+            <p>A streamlined workflow that scales from boutique cellars to enterprise wineries.</p>
+        </div>
+        <div class="process-steps">
+            <div class="step">
+                <div class="step-number">1</div>
+                <h3>Map Your Cellar</h3>
+                <p>Import tanks and barrels or design your layout in minutes with guided templates.</p>
             </div>
-            <div class="form-group">
-                <label for="targetPH">Target pH</label>
-                <input type="number" id="targetPH" step="0.01" placeholder="e.g., 3.4">
+            <div class="step">
+                <div class="step-number">2</div>
+                <h3>Capture Readings</h3>
+                <p>Use barcode scanning, mobile forms, or integrations to log every measurement instantly.</p>
             </div>
-            <div class="form-group">
-                <label for="phVolume">Volume (L)</label>
-                <input type="number" id="phVolume" step="0.1" placeholder="e.g., 100">
+            <div class="step">
+                <div class="step-number">3</div>
+                <h3>Monitor &amp; Optimise</h3>
+                <p>AI analytics highlight risks, recommend actions, and forecast completion.</p>
             </div>
-            <button type="button" id="calculatePH">Calculate Acid Addition</button>
-            <div id="phResult"></div>
-        </section>
+            <div class="step">
+                <div class="step-number">4</div>
+                <h3>Report &amp; Trace</h3>
+                <p>Generate compliance, traceability, and production reports ready for regulators and partners.</p>
+            </div>
+        </div>
+    </section>
 
-        <section class="log-display">
-            <h2>Log History for <span id="logTankId">...</span></h2>
-            <table id="logTable">
-                <thead>
-                    <tr>
-                        <th>Date & Time</th>
-                        <th>Temp (°C)</th>
-                        <th>Sugar (Baumé)</th>
-                        <th>Specific Gravity</th>
-                        <th>pH</th>
-                        <th>TA (g/L)</th>
-                        <th>Volume (L)</th>
-                        <th>Notes / Additions</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody id="logTableBody">
-                    </tbody>
-            </table>
-        </section>
-
-        <section class="data-management">
-            <h2>Data Management</h2>
-            <button id="exportJsonBtn">Export JSON</button>
-            <button id="exportCsvBtn">Export CSV</button>
-            <input type="file" id="importFile" accept=".json,.csv" style="display: none;">
-            <button id="importJsonBtn">Import JSON</button>
-            <button id="importCsvBtn">Import CSV</button>
-        </section>
-
-        <section class="fermentation-analytics">
-            <h2>Fermentation Analytics</h2>
-            <div class="analytics-grid">
-                <div class="chart-container">
-                    <canvas id="fermentationCurveChart"></canvas>
-                </div>
-                <div class="chart-container">
-                    <canvas id="multiParameterChart"></canvas>
+    <section id="compliance" class="compliance-section">
+        <div class="compliance-content">
+            <div class="compliance-text">
+                <h2>OIV &amp; Regulatory Compliance</h2>
+                <p>Stay inspection-ready with validated templates and continuous monitoring against global standards.</p>
+                <ul class="compliance-list">
+                    <li>SO₂, mass balance, and additives ledger</li>
+                    <li>TTB, EU, and export documentation</li>
+                    <li>Digital signatures &amp; audit trails</li>
+                    <li>HACCP and sustainability tracking</li>
+                </ul>
+            </div>
+            <div class="compliance-visual" aria-hidden="true">
+                <div class="compliance-ring ring-one"></div>
+                <div class="compliance-ring ring-two"></div>
+                <div class="compliance-ring ring-three"></div>
+                <div class="compliance-center">
+                    <span>100%</span>
+                    <small>Audit Ready</small>
                 </div>
             </div>
-        </section>
+        </div>
+    </section>
 
-        <section class="alerts-monitoring">
-            <div id="alertsPanel"></div>
-        </section>
+    <section id="testimonials" class="testimonials-section">
+        <div class="section-header">
+            <h2>Trusted by Professional Winemakers</h2>
+            <p>Industry experts rely on VineTrack Pro to run safer, smarter cellars.</p>
+        </div>
+        <div class="testimonials-grid">
+            <article class="testimonial-card">
+                <p class="testimonial-content">“VineTrack Pro has transformed our fermentation monitoring. The AI completion forecasts are spot on and compliance paperwork is automatic.”</p>
+                <div class="testimonial-author">
+                    <div class="author-avatar" aria-hidden="true"><span>SC</span></div>
+                    <div>
+                        <strong>Sarah Chen</strong>
+                        <div>Lead Winemaker, Napa Valley Estate</div>
+                    </div>
+                </div>
+            </article>
+            <article class="testimonial-card">
+                <p class="testimonial-content">“Traceability is finally effortless. Customers love receiving a full production story for their allocations.”</p>
+                <div class="testimonial-author">
+                    <div class="author-avatar" aria-hidden="true"><span>LR</span></div>
+                    <div>
+                        <strong>Luca Rossi</strong>
+                        <div>Winemaker, Tuscany Vineyards</div>
+                    </div>
+                </div>
+            </article>
+            <article class="testimonial-card">
+                <p class="testimonial-content">“As a family winery, compliance was daunting. VineTrack Pro keeps us aligned with EU and US requirements without extra staff.”</p>
+                <div class="testimonial-author">
+                    <div class="author-avatar" aria-hidden="true"><span>EJ</span></div>
+                    <div>
+                        <strong>Emma Johnson</strong>
+                        <div>Owner, Heritage Cellars</div>
+                    </div>
+                </div>
+            </article>
+        </div>
+    </section>
 
-        <section class="team-collaboration">
-            <h2>Team Collaboration</h2>
-            <div id="collaborationPanel"></div>
-        </section>
+    <section id="pricing" class="pricing-section">
+        <div class="section-header">
+            <h2>Simple, Transparent Pricing</h2>
+            <p>Flexible plans for every stage of growth. Cancel any time.</p>
+        </div>
+        <div class="pricing-cards">
+            <article class="pricing-card">
+                <h3>Starter</h3>
+                <p class="price">$49<span>/month</span></p>
+                <p class="price-subtitle">Perfect for boutique wineries</p>
+                <ul class="pricing-features">
+                    <li>Up to 10 tanks</li>
+                    <li>Core fermentation tracking</li>
+                    <li>Compliance exports</li>
+                    <li>Email support</li>
+                </ul>
+                <a href="enhanced-dashboard.html" class="btn-primary">Start Trial</a>
+            </article>
+            <article class="pricing-card featured">
+                <div class="featured-label">Most Popular</div>
+                <h3>Professional</h3>
+                <p class="price">$99<span>/month</span></p>
+                <p class="price-subtitle">Everything a production cellar needs</p>
+                <ul class="pricing-features">
+                    <li>Unlimited tanks</li>
+                    <li>Advanced AI analytics</li>
+                    <li>Lab &amp; ERP integrations</li>
+                    <li>Priority support</li>
+                </ul>
+                <a href="enhanced-dashboard.html" class="btn-primary">Start Trial</a>
+            </article>
+            <article class="pricing-card">
+                <h3>Enterprise</h3>
+                <p class="price">Custom</p>
+                <p class="price-subtitle">Tailored for multi-site operations</p>
+                <ul class="pricing-features">
+                    <li>Dedicated CSM</li>
+                    <li>Custom integrations</li>
+                    <li>On-site training</li>
+                    <li>Premium SLA</li>
+                </ul>
+                <a href="#contact" class="btn-primary">Request Demo</a>
+            </article>
+        </div>
+    </section>
 
-        <section class="advanced-reporting">
-            <h2>Professional Reporting</h2>
-            <div class="reporting-controls">
-                <label for="reportStartDate">Start Date:</label>
-                <input type="date" id="reportStartDate">
-                
-                <label for="reportEndDate">End Date:</label>
-                <input type="date" id="reportEndDate">
-                
-                <button id="generateReportBtn">Generate Report</button>
-                <button id="exportPDFBtn">Export PDF</button>
+    <section id="demo" class="demo-section">
+        <div class="section-header">
+            <h2>Explore the Dashboard</h2>
+            <p>Preview the interactive control centre and see how insights flow across your cellar.</p>
+        </div>
+        <div class="demo-preview" aria-hidden="true">
+            <div class="demo-card">
+                <h3>Predictive Analytics</h3>
+                <p>AI forecasts fermentation completion and alerts you to deviations.</p>
             </div>
-        </section>
-    </main>
+            <div class="demo-card">
+                <h3>Digital Cellar Map</h3>
+                <p>Understand utilisation at a glance with capacity-aware layout visualisations.</p>
+            </div>
+            <div class="demo-card">
+                <h3>Compliance Centre</h3>
+                <p>Generate ready-to-submit filings and share secure read-only views.</p>
+            </div>
+        </div>
+    </section>
 
-    <!-- External libraries -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <section id="contact" class="contact-section">
+        <div class="contact-container">
+            <div class="contact-content">
+                <h2>Ready to transform your winemaking process?</h2>
+                <p>Join wineries that trust VineTrack Pro for reliable fermentation control and complete traceability.</p>
+                <a href="enhanced-dashboard.html" class="btn-primary btn-large">Start 14-Day Trial</a>
+                <p class="small-text">No credit card required. Cancel any time.</p>
+            </div>
+            <div class="contact-form">
+                <form id="contactForm">
+                    <div class="form-group">
+                        <label for="name">Full Name</label>
+                        <input type="text" id="name" name="name" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="email">Email Address</label>
+                        <input type="email" id="email" name="email" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="winery">Winery Name</label>
+                        <input type="text" id="winery" name="winery" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="tanks">Number of Tanks</label>
+                        <select id="tanks" name="tanks">
+                            <option value="1-5">1–5</option>
+                            <option value="6-10">6–10</option>
+                            <option value="11-20">11–20</option>
+                            <option value="21-50">21–50</option>
+                            <option value="50+">50+</option>
+                        </select>
+                    </div>
+                    <button type="submit" class="btn-primary">Get Started</button>
+                </form>
+            </div>
+        </div>
+    </section>
 
-    <!-- Application scripts -->
-    <script src="dataManager.js"></script>
-    <script src="calculations.js"></script>
-    <script src="validator.js"></script>
-    <script src="uiManager.js"></script>
-    <script src="visualizations.js"></script>
-    <script src="alertSystem.js"></script>
-    <script src="collaboration.js"></script>
-    <script src="reporting.js"></script>
-    <script src="batchManager.js"></script>
-    <script src="labIntegration.js"></script>
-    <script src="productionPlanner.js"></script>
-    <script src="complianceManager.js"></script>
-    <script src="aiAnalytics.js"></script>
-    <script src="apiIntegration.js"></script>
-    <script src="pwa.js"></script>
-    <script src="app.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-<script>
-  flatpickr("#timestamp", {
-    // This enables the time picker as well as the date picker
-    enableTime: true,
-    // This is the format the server needs
-    dateFormat: "Y-m-d H:i",
-    // This enables the alternate, user-friendly format
-    altInput: true,
-    // This is the format you will see: "day/month/year hour:minute"
-    altFormat: "d/m/Y H:i",
-    placeholder: "dd/mm/yyyy --:--",
-  });
-</script>
+    <footer class="site-footer">
+        <div class="footer-container">
+            <div class="footer-top">
+                <div class="footer-logo">
+                    <img src="assets/images/logo.svg" alt="VineTrack Pro" width="40" height="40">
+                    <h3>VineTrack Pro</h3>
+                </div>
+                <p class="footer-tagline">AI-enhanced, OIV-compliant winemaking management for modern cellars.</p>
+            </div>
+            <div class="footer-columns">
+                <div class="footer-column">
+                    <h4>Product</h4>
+                    <ul class="footer-links">
+                        <li><a href="#features">Features</a></li>
+                        <li><a href="enhanced-dashboard.html">Dashboard</a></li>
+                        <li><a href="#pricing">Pricing</a></li>
+                        <li><a href="#demo">Demo</a></li>
+                    </ul>
+                </div>
+                <div class="footer-column">
+                    <h4>Company</h4>
+                    <ul class="footer-links">
+                        <li><a href="#contact">About</a></li>
+                        <li><a href="#contact">Team</a></li>
+                        <li><a href="#contact">Careers</a></li>
+                        <li><a href="#contact">Press</a></li>
+                    </ul>
+                </div>
+                <div class="footer-column">
+                    <h4>Resources</h4>
+                    <ul class="footer-links">
+                        <li><a href="#how-it-works">Implementation</a></li>
+                        <li><a href="#demo">Product Tour</a></li>
+                        <li><a href="#contact">Support</a></li>
+                        <li><a href="#contact">Documentation</a></li>
+                    </ul>
+                </div>
+                <div class="footer-column">
+                    <h4>Contact</h4>
+                    <ul class="footer-links">
+                        <li><a href="mailto:support@vinetrackpro.com">support@vinetrackpro.com</a></li>
+                        <li><a href="tel:+18001234567">+1 (800) 123-4567</a></li>
+                        <li><a href="#contact">Sales Inquiries</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; <span id="year"></span> VineTrack Pro. All rights reserved.</p>
+                <div class="footer-social">
+                    <a href="https://twitter.com" aria-label="Twitter">Twitter</a>
+                    <a href="https://linkedin.com" aria-label="LinkedIn">LinkedIn</a>
+                    <a href="https://instagram.com" aria-label="Instagram">Instagram</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        const contactForm = document.getElementById('contactForm');
+        contactForm.addEventListener('submit', (event) => {
+            event.preventDefault();
+            const formData = new FormData(contactForm);
+            const name = formData.get('name');
+            const email = formData.get('email');
+            const winery = formData.get('winery');
+            alert(`Thank you, ${name}! Our team will reach out to ${email} about ${winery}.`);
+            contactForm.reset();
+        });
+
+        document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+            anchor.addEventListener('click', (event) => {
+                const targetId = anchor.getAttribute('href');
+                if (targetId.length > 1) {
+                    const target = document.querySelector(targetId);
+                    if (target) {
+                        event.preventDefault();
+                        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    }
+                }
+            });
+        });
+
+        const navLinks = document.querySelectorAll('.nav-link');
+        const sections = Array.from(document.querySelectorAll('section[id]'));
+        const setActiveNav = () => {
+            const scrollPosition = window.scrollY + 120;
+            let currentId = sections[0]?.id;
+            sections.forEach((section) => {
+                if (scrollPosition >= section.offsetTop) {
+                    currentId = section.id;
+                }
+            });
+            navLinks.forEach((link) => {
+                const linkTarget = link.getAttribute('href').replace('#', '');
+                if (linkTarget && linkTarget === currentId) {
+                    link.classList.add('active');
+                } else {
+                    link.classList.remove('active');
+                }
+            });
+        };
+        window.addEventListener('scroll', setActiveNav);
+        window.addEventListener('load', () => {
+            setActiveNav();
+            document.getElementById('year').textContent = new Date().getFullYear();
+        });
+    </script>
 </body>
 </html>

--- a/workflowManager.js
+++ b/workflowManager.js
@@ -1,0 +1,505 @@
+class HarvestWorkflowManager {
+    constructor(dataManager, batchManager) {
+        this.dataManager = dataManager ?? null;
+        this.batchManager = batchManager ?? null;
+        this.storageKey = 'vinetrack-harvest-workflows';
+        this.storageAvailable = this.checkStorageAvailability();
+        this.memoryStore = [];
+        this.workflows = this.loadWorkflows();
+    }
+
+    checkStorageAvailability() {
+        if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+            return false;
+        }
+        try {
+            const testKey = '__vinetrack_workflow_test__';
+            window.localStorage.setItem(testKey, '1');
+            window.localStorage.removeItem(testKey);
+            return true;
+        } catch (error) {
+            console.warn('Workflow storage unavailable, using in-memory persistence only.', error);
+            return false;
+        }
+    }
+
+    cloneData(data) {
+        return JSON.parse(JSON.stringify(data));
+    }
+
+    normalizeWorkflow(raw) {
+        const base = {
+            id: raw?.id ?? `INTAKE-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            arrival: {
+                time: raw?.arrival?.time ?? new Date().toISOString(),
+                vehicleType: raw?.arrival?.vehicleType ?? 'tractor-trailer',
+                driver: raw?.arrival?.driver ?? null,
+                crateCount: Number.isFinite(raw?.arrival?.crateCount) ? Number(raw.arrival.crateCount) : 0,
+                crateWeight: Number.isFinite(raw?.arrival?.crateWeight) ? Number(raw.arrival.crateWeight) : 0,
+                totalWeight: Number.isFinite(raw?.arrival?.totalWeight) ? Number(raw.arrival.totalWeight) : null,
+                notes: raw?.arrival?.notes ?? ''
+            },
+            grapes: {
+                variety: raw?.grapes?.variety ?? '',
+                vineyard: raw?.grapes?.vineyard ?? '',
+                block: raw?.grapes?.block ?? ''
+            },
+            route: raw?.route ?? 'press',
+            status: raw?.status ?? 'intake',
+            destemming: {
+                completed: Boolean(raw?.destemming?.completed ?? false),
+                timestamp: raw?.destemming?.timestamp ?? null,
+                notes: raw?.destemming?.notes ?? ''
+            },
+            pressing: {
+                completed: Boolean(raw?.pressing?.completed ?? false),
+                timestamp: raw?.pressing?.timestamp ?? null,
+                pressId: raw?.pressing?.pressId ?? '',
+                mustVolume: Number.isFinite(raw?.pressing?.mustVolume) ? Number(raw.pressing.mustVolume) : null,
+                notes: raw?.pressing?.notes ?? ''
+            },
+            settling: {
+                active: Boolean(raw?.settling?.active ?? false),
+                tankId: raw?.settling?.tankId ?? '',
+                start: raw?.settling?.start ?? null,
+                end: raw?.settling?.end ?? null,
+                expectedHours: Number.isFinite(raw?.settling?.expectedHours) ? Number(raw.settling.expectedHours) : null,
+                durationHours: Number.isFinite(raw?.settling?.durationHours) ? Number(raw.settling.durationHours) : null,
+                notes: raw?.settling?.notes ?? '',
+                clarity: raw?.settling?.clarity ?? ''
+            },
+            fermentation: {
+                started: Boolean(raw?.fermentation?.started ?? false),
+                tankId: raw?.fermentation?.tankId ?? '',
+                yeast: raw?.fermentation?.yeast ?? '',
+                inoculatedAt: raw?.fermentation?.inoculatedAt ?? null,
+                volume: Number.isFinite(raw?.fermentation?.volume) ? Number(raw.fermentation.volume) : null,
+                plannedVolume: Number.isFinite(raw?.fermentation?.plannedVolume) ? Number(raw.fermentation.plannedVolume) : null,
+                startingDensity: raw?.fermentation?.startingDensity ?? null,
+                densityScale: raw?.fermentation?.densityScale ?? 'Brix',
+                startingTemperature: Number.isFinite(raw?.fermentation?.startingTemperature)
+                    ? Number(raw.fermentation.startingTemperature)
+                    : null,
+                startingPh: Number.isFinite(raw?.fermentation?.startingPh) ? Number(raw.fermentation.startingPh) : null,
+                notes: raw?.fermentation?.notes ?? '',
+                readings: Array.isArray(raw?.fermentation?.readings)
+                    ? raw.fermentation.readings.map(reading => ({
+                        timestamp: reading?.timestamp ?? new Date().toISOString(),
+                        temperature: Number.isFinite(reading?.temperature) ? Number(reading.temperature) : null,
+                        density: Number.isFinite(reading?.density) ? Number(reading.density) : null,
+                        scale: reading?.scale ?? 'Brix',
+                        ph: Number.isFinite(reading?.ph) ? Number(reading.ph) : null,
+                        notes: reading?.notes ?? ''
+                    }))
+                    : []
+            },
+            burb: {
+                fermenting: Boolean(raw?.burb?.fermenting ?? false),
+                startedAt: raw?.burb?.startedAt ?? null,
+                bentoniteAddedAt: raw?.burb?.bentoniteAddedAt ?? null,
+                notes: raw?.burb?.notes ?? ''
+            },
+            additions: Array.isArray(raw?.additions)
+                ? raw.additions.map(addition => ({
+                    id: addition?.id ?? `ADD-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+                    stage: addition?.stage ?? 'destemming',
+                    product: addition?.product ?? '',
+                    amount: Number.isFinite(addition?.amount) ? Number(addition.amount) : null,
+                    unit: addition?.unit ?? '',
+                    timestamp: addition?.timestamp ?? new Date().toISOString(),
+                    notes: addition?.notes ?? ''
+                }))
+                : [],
+            history: Array.isArray(raw?.history)
+                ? raw.history.map(entry => ({
+                    id: entry?.id ?? `WFH-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+                    type: entry?.type ?? 'update',
+                    summary: entry?.summary ?? '',
+                    detail: entry?.detail ?? null,
+                    timestamp: entry?.timestamp ?? new Date().toISOString()
+                }))
+                : []
+        };
+
+        if (!base.arrival.totalWeight && base.arrival.crateCount && base.arrival.crateWeight) {
+            base.arrival.totalWeight = base.arrival.crateCount * base.arrival.crateWeight;
+        }
+
+        return base;
+    }
+
+    loadWorkflows() {
+        let stored = [];
+        if (this.storageAvailable) {
+            try {
+                const raw = window.localStorage.getItem(this.storageKey);
+                stored = raw ? JSON.parse(raw) : [];
+            } catch (error) {
+                console.warn('Unable to load harvest workflows from storage.', error);
+                this.storageAvailable = false;
+            }
+        }
+        const normalized = Array.isArray(stored) ? stored.map(entry => this.normalizeWorkflow(entry)) : [];
+        if (!this.storageAvailable) {
+            this.memoryStore = this.cloneData(normalized);
+        }
+        return normalized;
+    }
+
+    persist() {
+        if (this.storageAvailable) {
+            try {
+                window.localStorage.setItem(this.storageKey, JSON.stringify(this.workflows));
+                return;
+            } catch (error) {
+                console.warn('Persisting harvest workflows to local storage failed. Falling back to memory.', error);
+                this.storageAvailable = false;
+            }
+        }
+        this.memoryStore = this.cloneData(this.workflows);
+    }
+
+    getWorkflows() {
+        return this.cloneData(this.workflows);
+    }
+
+    getWorkflowById(workflowId) {
+        return this.workflows.find(workflow => workflow.id === workflowId) ?? null;
+    }
+
+    toNumber(value) {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    addHistoryEntry(workflow, type, summary, detail = null) {
+        const entry = {
+            id: `WFH-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+            type,
+            summary,
+            detail,
+            timestamp: new Date().toISOString()
+        };
+        workflow.history.push(entry);
+        return entry;
+    }
+
+    createTransport(data) {
+        const workflow = this.normalizeWorkflow({
+            arrival: {
+                time: data?.arrivalTime ?? new Date().toISOString(),
+                vehicleType: data?.vehicleType ?? 'tractor-trailer',
+                driver: data?.driver ?? null,
+                crateCount: this.toNumber(data?.crateCount) ?? 0,
+                crateWeight: this.toNumber(data?.crateWeight) ?? null,
+                totalWeight: this.toNumber(data?.totalWeight) ?? null,
+                notes: data?.notes ?? ''
+            },
+            grapes: {
+                variety: data?.variety ?? '',
+                vineyard: data?.vineyard ?? '',
+                block: data?.block ?? ''
+            },
+            route: data?.route ?? 'press',
+            status: 'intake'
+        });
+        this.addHistoryEntry(workflow, 'intake', `Transport received (${workflow.arrival.vehicleType})`,
+            `${workflow.arrival.crateCount} crates • ${workflow.arrival.totalWeight ?? 'N/A'} kg`);
+        this.workflows.push(workflow);
+        this.persist();
+        return this.cloneData(workflow);
+    }
+
+    recordDestemming(workflowId, details) {
+        return this.updateWorkflow(workflowId, workflow => {
+            workflow.destemming.completed = true;
+            workflow.destemming.timestamp = details?.timestamp ?? new Date().toISOString();
+            workflow.destemming.notes = details?.notes ?? '';
+            workflow.route = details?.route ?? workflow.route ?? 'press';
+            workflow.status = 'destemmed';
+            if (details?.tankId) {
+                workflow.fermentation.tankId = details.tankId;
+            }
+            const estimatedVolume = this.toNumber(details?.estimatedVolume);
+            if (estimatedVolume !== null) {
+                workflow.fermentation.plannedVolume = estimatedVolume;
+            }
+            this.addHistoryEntry(
+                workflow,
+                'destemming',
+                workflow.route === 'press'
+                    ? 'Destemmed for pressing'
+                    : `Destemmed and routed to tank ${workflow.fermentation.tankId || ''}`,
+                details?.notes ?? null
+            );
+        });
+    }
+
+    recordAddition(workflowId, addition) {
+        return this.updateWorkflow(workflowId, workflow => {
+            const entry = {
+                id: `ADD-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+                stage: addition?.stage ?? 'destemming',
+                product: addition?.product ?? '',
+                amount: this.toNumber(addition?.amount),
+                unit: addition?.unit ?? '',
+                timestamp: addition?.timestamp ?? new Date().toISOString(),
+                notes: addition?.notes ?? ''
+            };
+            workflow.additions.push(entry);
+            this.addHistoryEntry(
+                workflow,
+                'addition',
+                `${entry.product || 'Addition'} added during ${entry.stage}`,
+                entry.amount !== null && entry.unit
+                    ? `${entry.amount} ${entry.unit}`
+                    : entry.unit || null
+            );
+            if (entry.stage === 'fermentation' && workflow.fermentation.started && this.batchManager && workflow.fermentation.tankId) {
+                const batch = this.batchManager.getBatchByTank(workflow.fermentation.tankId);
+                if (batch) {
+                    this.batchManager.addHistoryEntry(batch.id, {
+                        type: 'addition',
+                        data: {
+                            product: entry.product,
+                            amount: entry.amount,
+                            unit: entry.unit,
+                            workflowId
+                        },
+                        timestamp: entry.timestamp
+                    });
+                }
+            }
+        });
+    }
+
+    recordPressing(workflowId, details) {
+        return this.updateWorkflow(workflowId, workflow => {
+            workflow.pressing.completed = true;
+            workflow.pressing.timestamp = details?.timestamp ?? new Date().toISOString();
+            workflow.pressing.pressId = details?.pressId ?? '';
+            workflow.pressing.mustVolume = this.toNumber(details?.mustVolume);
+            workflow.pressing.notes = details?.notes ?? '';
+            workflow.status = 'pressed';
+            if (workflow.pressing.mustVolume !== null) {
+                workflow.fermentation.plannedVolume = workflow.pressing.mustVolume;
+            }
+            this.addHistoryEntry(
+                workflow,
+                'pressing',
+                'Press cycle completed',
+                workflow.pressing.mustVolume !== null ? `${workflow.pressing.mustVolume} L collected` : workflow.pressing.notes
+            );
+        });
+    }
+
+    startSettling(workflowId, details) {
+        return this.updateWorkflow(workflowId, workflow => {
+            workflow.settling.active = true;
+            workflow.settling.tankId = details?.tankId ?? workflow.settling.tankId ?? '';
+            workflow.settling.start = details?.start ?? new Date().toISOString();
+            workflow.settling.expectedHours = this.toNumber(details?.expectedHours);
+            workflow.settling.notes = details?.notes ?? '';
+            workflow.status = 'settling';
+            this.addHistoryEntry(
+                workflow,
+                'settling-start',
+                `Must settling in tank ${workflow.settling.tankId || ''}`,
+                workflow.settling.expectedHours
+                    ? `Expected ${workflow.settling.expectedHours} h`
+                    : workflow.settling.notes || null
+            );
+        });
+    }
+
+    completeSettling(workflowId, details) {
+        return this.updateWorkflow(workflowId, workflow => {
+            workflow.settling.end = details?.end ?? new Date().toISOString();
+            workflow.settling.clarity = details?.clarity ?? '';
+            workflow.settling.notes = details?.notes ?? workflow.settling.notes;
+            workflow.settling.active = false;
+            if (workflow.settling.start) {
+                const duration = (new Date(workflow.settling.end) - new Date(workflow.settling.start)) / (1000 * 60 * 60);
+                if (Number.isFinite(duration)) {
+                    workflow.settling.durationHours = Math.max(duration, 0);
+                }
+            }
+            workflow.status = 'settled';
+            this.addHistoryEntry(
+                workflow,
+                'settling-complete',
+                'Must settling complete',
+                workflow.settling.clarity ? `Clarity: ${workflow.settling.clarity}` : null
+            );
+        });
+    }
+
+    startFermentation(workflowId, details) {
+        return this.updateWorkflow(workflowId, workflow => {
+            workflow.fermentation.started = true;
+            workflow.fermentation.tankId = details?.tankId ?? workflow.fermentation.tankId ?? '';
+            workflow.fermentation.yeast = details?.yeast ?? '';
+            workflow.fermentation.inoculatedAt = details?.inoculatedAt ?? new Date().toISOString();
+            workflow.fermentation.volume = this.toNumber(details?.volume);
+            workflow.fermentation.plannedVolume = workflow.fermentation.volume ?? workflow.fermentation.plannedVolume;
+            workflow.fermentation.startingDensity = details?.density ?? workflow.fermentation.startingDensity;
+            workflow.fermentation.densityScale = details?.scale ?? workflow.fermentation.densityScale ?? 'Brix';
+            workflow.fermentation.startingTemperature = this.toNumber(details?.temperature) ?? workflow.fermentation.startingTemperature;
+            workflow.fermentation.startingPh = this.toNumber(details?.ph) ?? workflow.fermentation.startingPh;
+            workflow.fermentation.notes = details?.notes ?? workflow.fermentation.notes;
+            workflow.status = 'fermenting';
+
+            if (details?.density || details?.temperature || details?.ph) {
+                workflow.fermentation.readings.push({
+                    timestamp: workflow.fermentation.inoculatedAt,
+                    temperature: this.toNumber(details?.temperature),
+                    density: this.toNumber(details?.density),
+                    scale: details?.scale ?? 'Brix',
+                    ph: this.toNumber(details?.ph),
+                    notes: 'Initial inoculation reading'
+                });
+            }
+
+            const historyDetail = [
+                workflow.fermentation.yeast ? `Yeast: ${workflow.fermentation.yeast}` : null,
+                details?.notes ? details.notes : null
+            ].filter(Boolean).join(' • ') || null;
+            this.addHistoryEntry(
+                workflow,
+                'fermentation-start',
+                `Fermentation started in tank ${workflow.fermentation.tankId || ''}`,
+                historyDetail
+            );
+
+            if (this.batchManager && workflow.fermentation.tankId) {
+                const batch = this.batchManager.ensureBatchForTank(workflow.fermentation.tankId, {
+                    variety: workflow.grapes.variety || 'Unknown',
+                    vineyard: workflow.grapes.vineyard,
+                    harvestDate: workflow.arrival.time,
+                    volume: workflow.fermentation.volume ?? workflow.fermentation.plannedVolume ?? 0
+                });
+                if (batch) {
+                    this.batchManager.addHistoryEntry(batch.id, {
+                        type: 'fermentation-start',
+                        data: {
+                            workflowId,
+                            yeast: workflow.fermentation.yeast,
+                            volume: workflow.fermentation.volume ?? workflow.fermentation.plannedVolume ?? 0,
+                            notes: details?.notes ?? null
+                        },
+                        timestamp: workflow.fermentation.inoculatedAt
+                    });
+                }
+            }
+        });
+    }
+
+    recordFermentationReading(workflowId, reading) {
+        return this.updateWorkflow(workflowId, workflow => {
+            const entry = {
+                timestamp: reading?.timestamp ?? new Date().toISOString(),
+                temperature: this.toNumber(reading?.temperature),
+                density: this.toNumber(reading?.density),
+                scale: reading?.scale ?? workflow.fermentation.densityScale ?? 'Brix',
+                ph: this.toNumber(reading?.ph),
+                notes: reading?.notes ?? ''
+            };
+            workflow.fermentation.readings.push(entry);
+            this.addHistoryEntry(
+                workflow,
+                'fermentation-reading',
+                'Fermentation reading captured',
+                entry.density !== null
+                    ? `${entry.density} ${entry.scale}`
+                    : entry.temperature !== null
+                        ? `${entry.temperature} °C`
+                        : null
+            );
+
+            if (this.dataManager && workflow.fermentation.tankId) {
+                this.dataManager.addReading(workflow.fermentation.tankId, {
+                    timestamp: entry.timestamp,
+                    temperature: entry.temperature,
+                    sugar: entry.density,
+                    ph: entry.ph,
+                    notes: `Harvest workflow (${entry.scale}) ${entry.notes ?? ''}`.trim()
+                });
+            }
+
+            if (this.batchManager && workflow.fermentation.tankId) {
+                const batch = this.batchManager.getBatchByTank(workflow.fermentation.tankId);
+                if (batch) {
+                    this.batchManager.addHistoryEntry(batch.id, {
+                        type: 'reading',
+                        data: {
+                            workflowId,
+                            density: entry.density,
+                            scale: entry.scale,
+                            temperature: entry.temperature,
+                            ph: entry.ph
+                        },
+                        timestamp: entry.timestamp
+                    });
+                }
+            }
+        });
+    }
+
+    recordBurbProcessing(workflowId, details) {
+        return this.updateWorkflow(workflowId, workflow => {
+            workflow.burb.fermenting = true;
+            workflow.burb.startedAt = details?.startedAt ?? new Date().toISOString();
+            workflow.burb.bentoniteAddedAt = details?.bentoniteAddedAt ?? workflow.burb.bentoniteAddedAt;
+            workflow.burb.notes = details?.notes ?? workflow.burb.notes;
+            this.addHistoryEntry(
+                workflow,
+                'burb',
+                'Lees fermentation updated',
+                workflow.burb.bentoniteAddedAt ? `Bentonite at ${workflow.burb.bentoniteAddedAt}` : workflow.burb.notes || null
+            );
+        });
+    }
+
+    updateWorkflow(workflowId, mutator) {
+        const workflow = this.getWorkflowById(workflowId);
+        if (!workflow || typeof mutator !== 'function') {
+            return null;
+        }
+        mutator(workflow);
+        this.persist();
+        return this.cloneData(workflow);
+    }
+
+    getPendingDestemming() {
+        return this.workflows.filter(workflow => !workflow.destemming.completed);
+    }
+
+    getActiveSettling() {
+        return this.workflows.filter(workflow => workflow.settling.start && !workflow.settling.end);
+    }
+
+    getFermentationWithoutRecentReadings(hours = 36) {
+        const thresholdMs = hours * 60 * 60 * 1000;
+        const now = Date.now();
+        return this.workflows.filter(workflow => {
+            if (!workflow.fermentation.started) {
+                return false;
+            }
+            const readings = workflow.fermentation.readings;
+            if (!Array.isArray(readings) || readings.length === 0) {
+                return true;
+            }
+            const last = readings[readings.length - 1];
+            if (!last?.timestamp) {
+                return true;
+            }
+            const age = now - new Date(last.timestamp).getTime();
+            return !Number.isNaN(age) && age > thresholdMs;
+        });
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.HarvestWorkflowManager = HarvestWorkflowManager;
+}
+


### PR DESCRIPTION
## Summary
- introduce a HarvestWorkflowManager to persist transports, destemming, pressing, settling, fermentation, and lees handling events
- extend the production view with an intake form and workflow board that surfaces next actions, readings, and history per lot
- style the new workflow components to match the glassmorphism dashboard and surface warnings for overdue settling or stale readings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3a8651e10832dad4f5a1e0a55abea